### PR TITLE
Add Codex sandbox calendar permission and split agent targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ ical/
 - Recurrence display: human-readable ("Every 2 weeks on Mon, Wed")
 - Color coding: calendar colors shown, all-day events highlighted
 - Interactive mode (`-i`): add and update support guided huh forms
-- `ical skills install` writes embedded skill files to `~/.claude/skills/ical-cli/` or `~/.agents/skills/ical-cli/`
+- `ical skills install` writes embedded skill files to `~/.claude/skills/ical-cli/`, `~/.codex/skills/ical-cli/`, or `~/.agents/skills/ical-cli/`
 - Background update check: goroutine in PersistentPreRun, 2s timeout, 24h cache at `~/.cache/ical/update-check`
 - `ICAL_NO_UPDATE_CHECK=1` disables update check; also skipped for json output, piped stdout, dev builds
 

--- a/README.md
+++ b/README.md
@@ -317,8 +317,9 @@ ical skills install
 
 # Install for a specific agent
 ical skills install --agent claude    # → ~/.claude/skills/ical-cli/
-ical skills install --agent codex     # → ~/.agents/skills/ical-cli/
+ical skills install --agent codex     # → ~/.codex/skills/ical-cli/
 ical skills install --agent openclaw  # → ~/.openclaw/skills/ical-cli/
+ical skills install --agent others    # → ~/.agents/skills/ical-cli/
 ical skills install --agent all       # All agents
 
 # Check installation status

--- a/cmd/ical/commands/skills.go
+++ b/cmd/ical/commands/skills.go
@@ -41,8 +41,9 @@ var skillsInstallCmd = &cobra.Command{
 
 Supported agents:
   claude    → ~/.claude/skills/ical-cli/    (Claude Code, Copilot, Cursor, OpenCode, Augment)
-  codex     → ~/.agents/skills/ical-cli/    (Codex CLI, Copilot, Windsurf, OpenCode, Augment)
+  codex     → ~/.codex/skills/ical-cli/     (Codex CLI)
   openclaw  → ~/.openclaw/skills/ical-cli/  (OpenClaw)
+  others    → ~/.agents/skills/ical-cli/    (Copilot, Windsurf, OpenCode, Augment)
 
 Without --agent, shows an interactive picker to select which agents to install for.
 
@@ -53,7 +54,7 @@ https://ical.sidv.dev/docs — use --dry-run to preview what will be written.`,
 }
 
 func init() {
-	skillsInstallCmd.Flags().StringVar(&skillsAgentFlag, "agent", "", "Agent target: claude, codex, openclaw, or all")
+	skillsInstallCmd.Flags().StringVar(&skillsAgentFlag, "agent", "", "Agent target: claude, codex, openclaw, others, or all")
 	skillsInstallCmd.Flags().BoolVar(&skillsInstallDryRun, "dry-run", false, "Preview what would be installed without writing anything")
 	skillsCmd.AddCommand(skillsInstallCmd)
 }
@@ -182,7 +183,7 @@ var skillsUninstallCmd = &cobra.Command{
 }
 
 func init() {
-	skillsUninstallCmd.Flags().StringVar(&skillsAgentFlag, "agent", "", "Agent target: claude, codex, openclaw, or all")
+	skillsUninstallCmd.Flags().StringVar(&skillsAgentFlag, "agent", "", "Agent target: claude, codex, openclaw, others, or all")
 	skillsCmd.AddCommand(skillsUninstallCmd)
 }
 
@@ -303,7 +304,7 @@ func resolveAgentFlag(allTargets []skills.AgentTarget, flag string) ([]skills.Ag
 			return []skills.AgentTarget{t}, nil
 		}
 	}
-	return nil, fmt.Errorf("unknown agent %q (valid: claude, codex, openclaw, all)", flag)
+	return nil, fmt.Errorf("unknown agent %q (valid: claude, codex, openclaw, others, all)", flag)
 }
 
 func runAgentPicker(allTargets []skills.AgentTarget, homeDir, action string) ([]skills.AgentTarget, error) {

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -26,12 +26,17 @@ func DefaultTargets(homeDir string) []AgentTarget {
 		{
 			Name:    "Codex CLI",
 			Key:     "codex",
-			BaseDir: filepath.Join(homeDir, ".agents", "skills"),
+			BaseDir: filepath.Join(homeDir, ".codex", "skills"),
 		},
 		{
 			Name:    "OpenClaw",
 			Key:     "openclaw",
 			BaseDir: filepath.Join(homeDir, ".openclaw", "skills"),
+		},
+		{
+			Name:    "Others",
+			Key:     "others",
+			BaseDir: filepath.Join(homeDir, ".agents", "skills"),
 		},
 	}
 }

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestDefaultTargets(t *testing.T) {
 	targets := DefaultTargets("/home/user")
-	if len(targets) != 3 {
-		t.Fatalf("expected 3 targets, got %d", len(targets))
+	if len(targets) != 4 {
+		t.Fatalf("expected 4 targets, got %d", len(targets))
 	}
 
 	if targets[0].Key != "claude" {
@@ -24,8 +24,8 @@ func TestDefaultTargets(t *testing.T) {
 	if targets[1].Key != "codex" {
 		t.Errorf("expected second target key 'codex', got %q", targets[1].Key)
 	}
-	if targets[1].BaseDir != "/home/user/.agents/skills" {
-		t.Errorf("expected codex base dir '/home/user/.agents/skills', got %q", targets[1].BaseDir)
+	if targets[1].BaseDir != "/home/user/.codex/skills" {
+		t.Errorf("expected codex base dir '/home/user/.codex/skills', got %q", targets[1].BaseDir)
 	}
 
 	if targets[2].Key != "openclaw" {
@@ -36,6 +36,13 @@ func TestDefaultTargets(t *testing.T) {
 	}
 	if !strings.Contains(targets[2].BaseDir, ".openclaw/skills") {
 		t.Errorf("expected openclaw base dir to contain '.openclaw/skills', got %q", targets[2].BaseDir)
+	}
+
+	if targets[3].Key != "others" {
+		t.Errorf("expected fourth target key 'others', got %q", targets[3].Key)
+	}
+	if targets[3].BaseDir != "/home/user/.agents/skills" {
+		t.Errorf("expected others base dir '/home/user/.agents/skills', got %q", targets[3].BaseDir)
 	}
 }
 
@@ -337,14 +344,15 @@ func TestDetectAgentsBothPresent(t *testing.T) {
 func TestDetectAgentsAllPresent(t *testing.T) {
 	tmpDir := t.TempDir()
 	os.MkdirAll(filepath.Join(tmpDir, ".claude", "skills"), 0o755)
-	os.MkdirAll(filepath.Join(tmpDir, ".agents", "skills"), 0o755)
+	os.MkdirAll(filepath.Join(tmpDir, ".codex", "skills"), 0o755)
 	os.MkdirAll(filepath.Join(tmpDir, ".openclaw", "skills"), 0o755)
+	os.MkdirAll(filepath.Join(tmpDir, ".agents", "skills"), 0o755)
 
 	targets := DefaultTargets(tmpDir)
 	detected := DetectAgents(targets)
 
-	if len(detected) != 3 {
-		t.Errorf("expected 3 detected agents, got %d", len(detected))
+	if len(detected) != 4 {
+		t.Errorf("expected 4 detected agents, got %d", len(detected))
 	}
 }
 

--- a/skills/ical-cli/SKILL.md
+++ b/skills/ical-cli/SKILL.md
@@ -5,6 +5,9 @@ metadata:
   author: BRO3886
   version: "0.7.0"
 compatibility: Requires macOS with Calendar.app. Requires Xcode Command Line Tools for building from source.
+permissions:
+  macos:
+    macos_calendar: true
 ---
 
 # ical — CLI for macOS Calendar
@@ -95,7 +98,7 @@ ical export --format ics --from today --to "in 30 days" --output-file events.ics
 
 | Command                 | Aliases | Description                                                                    |
 | ----------------------- | ------- | ------------------------------------------------------------------------------ |
-| `ical skills install`   | —       | Install ical skill for Claude Code / Codex / OpenClaw (`--dry-run` to preview) |
+| `ical skills install`   | —       | Install ical skill for Claude Code / Codex / OpenClaw / others (`--dry-run` to preview) |
 | `ical skills uninstall` | —       | Remove ical agent skill                                                        |
 | `ical skills status`    | —       | Show skill installation status                                                 |
 | `ical version`          | —       | Print version and build info                                                   |

--- a/skills/ical-cli/references/commands.md
+++ b/skills/ical-cli/references/commands.md
@@ -364,13 +364,14 @@ ical skills install --agent all       # All agents
 
 | Flag        | Short | Description                                         | Default     |
 | ----------- | ----- | --------------------------------------------------- | ----------- |
-| `--agent`   | —     | Target agent: claude, codex, openclaw, or all       | Interactive |
-| `--dry-run` | —     | Preview what would be installed without writing      | false       |
+| `--agent`   | —     | Target agent: claude, codex, openclaw, others, or all | Interactive |
+| `--dry-run` | —     | Preview what would be installed without writing        | false       |
 
 Supported targets:
 - `claude` → `~/.claude/skills/ical-cli/` (Claude Code, GitHub Copilot, Cursor, OpenCode, Augment)
-- `codex` → `~/.agents/skills/ical-cli/` (Codex CLI, GitHub Copilot, Windsurf, OpenCode, Augment)
+- `codex` → `~/.codex/skills/ical-cli/` (Codex CLI)
 - `openclaw` → `~/.openclaw/skills/ical-cli/` (OpenClaw)
+- `others` → `~/.agents/skills/ical-cli/` (Copilot, Windsurf, OpenCode, Augment)
 
 ### ical skills uninstall
 

--- a/website/content/docs/architecture.md
+++ b/website/content/docs/architecture.md
@@ -97,7 +97,7 @@ When `--to` resolves to midnight (00:00:00), ical bumps it to 23:59:59 so that `
 
 ### Embedded Agent Skills
 
-ical embeds its own [agent skill](https://agentskills.io) files into the binary via `go:embed`. When a user runs `ical skills install`, the embedded files are written to the appropriate agent's skill directory (`~/.claude/skills/` or `~/.agents/skills/`). This ensures the skill documentation always matches the binary version — no separate download or version mismatch possible.
+ical embeds its own [agent skill](https://agentskills.io) files into the binary via `go:embed`. When a user runs `ical skills install`, the embedded files are written to the appropriate agent's skill directory (`~/.claude/skills/`, `~/.codex/skills/`, `~/.openclaw/skills/`, or `~/.agents/skills/`). This ensures the skill documentation always matches the binary version — no separate download or version mismatch possible.
 
 A `.ical-version` file is written alongside the skill files to track which binary version installed them. When the binary is updated, `ical skills status` detects the mismatch and the background update check prints a staleness notice.
 

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -25,7 +25,7 @@ ical provides commands for managing macOS Calendar events and calendars. Every c
 | `ical search [query]`            | Search events                                     |
 | `ical export`                     | Export events (JSON/CSV/ICS)                      |
 | `ical import [file]`             | Import events (JSON/CSV)                          |
-| `ical skills install`             | Install AI agent skill (Claude Code / Codex / OpenClaw) |
+| `ical skills install`             | Install AI agent skill (Claude Code / Codex / OpenClaw / others) |
 | `ical skills uninstall`           | Remove AI agent skill                             |
 | `ical skills status`              | Show skill installation status                    |
 | `ical version`                    | Show version info                                 |
@@ -475,22 +475,24 @@ ical skills install
 
 # Direct
 ical skills install --agent claude    # → ~/.claude/skills/ical-cli/
-ical skills install --agent codex     # → ~/.agents/skills/ical-cli/
+ical skills install --agent codex     # → ~/.codex/skills/ical-cli/
 ical skills install --agent openclaw  # → ~/.openclaw/skills/ical-cli/
+ical skills install --agent others    # → ~/.agents/skills/ical-cli/
 ical skills install --agent all       # All agents
 ```
 
 #### Flags
 
-| Flag        | Description                                              |
-|-------------|----------------------------------------------------------|
-| `--agent`   | Target agent: `claude`, `codex`, `openclaw`, or `all`    |
-| `--dry-run` | Preview what would be installed without writing           |
+| Flag        | Description                                                      |
+|-------------|------------------------------------------------------------------|
+| `--agent`   | Target agent: `claude`, `codex`, `openclaw`, `others`, or `all`  |
+| `--dry-run` | Preview what would be installed without writing                   |
 
 Supported targets:
 - **claude** → `~/.claude/skills/ical-cli/` — works with Claude Code, GitHub Copilot, Cursor, OpenCode, Augment
-- **codex** → `~/.agents/skills/ical-cli/` — works with Codex CLI, GitHub Copilot, Windsurf, OpenCode, Augment
+- **codex** → `~/.codex/skills/ical-cli/` — works with Codex CLI
 - **openclaw** → `~/.openclaw/skills/ical-cli/` — works with OpenClaw
+- **others** → `~/.agents/skills/ical-cli/` — works with Copilot, Windsurf, OpenCode, Augment
 
 ---
 
@@ -507,7 +509,7 @@ ical skills uninstall --agent claude
 
 | Flag      | Description                          |
 |-----------|--------------------------------------|
-| `--agent` | Target agent: `claude`, `codex`, or `all` |
+| `--agent` | Target agent: `claude`, `codex`, `openclaw`, `others`, or `all` |
 
 ---
 


### PR DESCRIPTION
## Summary
- Added `permissions.macos.macos_calendar: true` to SKILL.md frontmatter so Codex allows the CalendarAgent mach IPC through its seatbelt sandbox in default (non-Full Access) mode
- Split Codex target from `~/.agents/skills/` to `~/.codex/skills/` (its actual skill path per the reporter's setup)
- Added new "others" target at `~/.agents/skills/` for Copilot, Windsurf, OpenCode, Augment, etc.
- Updated all docs: SKILL.md, references/commands.md, website commands page, website architecture page, CLAUDE.md, README

Refs #3

## Test plan
- [x] `go test ./...` passes
- [x] `ical skills install --dry-run --agent all` shows all four targets with correct paths
- [ ] Verify `ical skills install --agent codex` writes to `~/.codex/skills/ical-cli/`
- [ ] Verify Codex with default permissions can run `ical upcoming` (needs someone with Codex to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
