### PR TITLE
feat(list,search): add --attendee flag for filtering by attendee

### DIFF
--- a/cmd/ical/commands/attendee_test.go
+++ b/cmd/ical/commands/attendee_test.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+)
+
+func TestAttendeeMatches(t *testing.T) {
+	tests := []struct {
+		name  string
+		event calendar.Event
+		query string
+		want  bool
+	}{
+		{
+			name: "name match case insensitive",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+			},
+			query: "sarah",
+			want:  true,
+		},
+		{
+			name: "email match",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Bob Jones", Email: "bob@example.com"},
+				},
+			},
+			query: "bob@example",
+			want:  true,
+		},
+		{
+			name: "organizer match",
+			event: calendar.Event{
+				Organizer: "Alice Johnson",
+			},
+			query: "alice",
+			want:  true,
+		},
+		{
+			name: "substring match",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+			},
+			query: "smi",
+			want:  true,
+		},
+		{
+			name:  "no attendees returns false",
+			event: calendar.Event{},
+			query: "anyone",
+			want:  false,
+		},
+		{
+			name: "no match returns false",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+				Organizer: "Bob Jones",
+			},
+			query: "charlie",
+			want:  false,
+		},
+		{
+			name: "multiple attendees one matches",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Alice Brown", Email: "alice@example.com"},
+					{Name: "Bob Green", Email: "bob@example.com"},
+					{Name: "Carol White", Email: "carol@example.com"},
+				},
+			},
+			query: "bob",
+			want:  true,
+		},
+		{
+			name: "uppercase query matches lowercase name",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "sarah smith", Email: "sarah@example.com"},
+				},
+			},
+			query: "sarah",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := attendeeMatches(tt.event, tt.query)
+			if got != tt.want {
+				t.Errorf("attendeeMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -22,6 +22,7 @@ var (
 	listSort            string
 	listLimit           int
 	listExcludeCalendar []string
+	listAttendee        string
 )
 
 var listCmd = &cobra.Command{
@@ -64,6 +65,7 @@ func init() {
 	listCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	listCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	listCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
+	listCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(listCmd)
 }
@@ -98,6 +100,17 @@ func listEvents(from, to time.Time) error {
 		filtered := make([]calendar.Event, 0, len(events))
 		for _, e := range events {
 			if !excluded[strings.ToLower(e.Calendar)] {
+				filtered = append(filtered, e)
+			}
+		}
+		events = filtered
+	}
+
+	if listAttendee != "" {
+		query := strings.ToLower(listAttendee)
+		filtered := make([]calendar.Event, 0, len(events))
+		for _, e := range events {
+			if attendeeMatches(e, query) {
 				filtered = append(filtered, e)
 			}
 		}
@@ -161,4 +174,22 @@ func endOfDayIfMidnight(t time.Time) time.Time {
 		return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, t.Location())
 	}
 	return t
+}
+
+// attendeeMatches returns true if any attendee name/email or the organizer
+// matches the query (case-insensitive substring). The query must already be
+// lowercased by the caller.
+func attendeeMatches(e calendar.Event, query string) bool {
+	for _, att := range e.Attendees {
+		if strings.Contains(strings.ToLower(att.Name), query) {
+			return true
+		}
+		if strings.Contains(strings.ToLower(att.Email), query) {
+			return true
+		}
+	}
+	if e.Organizer != "" && strings.Contains(strings.ToLower(e.Organizer), query) {
+		return true
+	}
+	return false
 }

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -16,6 +16,7 @@ var (
 	searchTo       string
 	searchCalendar string
 	searchLimit    int
+	searchAttendee string
 )
 
 var searchCmd = &cobra.Command{
@@ -61,6 +62,17 @@ var searchCmd = &cobra.Command{
 			return fmt.Errorf("failed to search events: %w", err)
 		}
 
+		if searchAttendee != "" {
+			attendeeQuery := strings.ToLower(searchAttendee)
+			filtered := make([]calendar.Event, 0, len(events))
+			for _, e := range events {
+				if attendeeMatches(e, attendeeQuery) {
+					filtered = append(filtered, e)
+				}
+			}
+			events = filtered
+		}
+
 		if searchLimit > 0 && len(events) > searchLimit {
 			events = events[:searchLimit]
 		}
@@ -75,6 +87,7 @@ func init() {
 	searchCmd.Flags().StringVarP(&searchTo, "to", "t", "", "End of search range (default: 30 days ahead)")
 	searchCmd.Flags().StringVarP(&searchCalendar, "calendar", "c", "", "Filter by calendar")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 0, "Max results")
+	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -87,7 +87,7 @@ func init() {
 	searchCmd.Flags().StringVarP(&searchTo, "to", "t", "", "End of search range (default: 30 days ahead)")
 	searchCmd.Flags().StringVarP(&searchCalendar, "calendar", "c", "", "Filter by calendar")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 0, "Max results")
-	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee name or email")
+	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
 
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/ical/commands/today.go
+++ b/cmd/ical/commands/today.go
@@ -26,6 +26,7 @@ func init() {
 	todayCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	todayCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	todayCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
+	todayCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(todayCmd)
 }

--- a/cmd/ical/commands/upcoming.go
+++ b/cmd/ical/commands/upcoming.go
@@ -30,6 +30,7 @@ func init() {
 	upcomingCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	upcomingCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	upcomingCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
+	upcomingCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(upcomingCmd)
 }


### PR DESCRIPTION
## Summary

- Adds `--attendee` / `-a` flag to `list`, `search`, `today`, and `upcoming` commands
- Filters events by case-insensitive substring match against attendee names, emails, and organizer
- Follows the existing in-memory filter pattern used by `--all-day` and `--exclude-calendar`
- All filters AND together: calendar + date range + search + attendee

## Motivation

A common use case is quickly finding the last meeting you had with a given person, e.g. "when did I last meet with Sarah?" Currently ical can search by title and filter by calendar, but there's no way to filter by who was in the meeting. The attendee data is already on every event via go-eventkit -- this just makes it queryable.

## Examples

```bash
# Find today's meetings with Sarah
ical today --attendee sarah

# Search standups with Bob
ical search standup --attendee bob

# List meetings with someone in a date range
ical list -a alice -f "last monday" -t friday

# Works with upcoming too
ical upcoming -d 14 --attendee carol
```

## Implementation

- `attendeeMatches(event, query)` helper in `list.go` checks each `event.Attendees[].Name`, `.Email`, and `event.Organizer` (case-insensitive substring)
- `listAttendee` package var shared by list/today/upcoming (they all call `listEvents()`)
- `searchAttendee` separate var for search (follows existing `searchFrom`/`searchCalendar` pattern)
- Flag registered on all 4 commands explicitly (today/upcoming don't inherit flags from list)

## Test plan

- [x] 8 unit tests in `attendee_test.go` (name, email, organizer, substring, no attendees, no match, multiple attendees, case insensitive)
- [x] Manual verification: `today -a`, `list --attendee`, `search --attendee`, `upcoming --attendee`
- [x] `go build` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)