### PR TITLE
Add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Full CRUD for calendar events, natural language dates, recurrence support, impor
 
 ## Install
 
+### Homebrew
+
+```bash
+brew tap BRO3886/tap
+brew install ical
+```
+
 **Quick install (recommended):**
 
 ```bash


### PR DESCRIPTION
A Homebrew tap (BRO3886/tap) has been set up for ical. This PR adds install instructions to the README so users can install via `brew tap BRO3886/tap && brew install ical`.

Homebrew is placed first in the Install section as the easiest install method for macOS users.
