### PR TITLE
Add Homebrew as primary install method on website

### DIFF
--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started"
-description: "Install ical and start managing your macOS Calendar from the terminal. Supports curl install, go install, and manual download on macOS."
-keywords: ["install ical macOS", "macOS Calendar CLI install", "go install ical", "ical getting started", "EventKit CLI setup", "Claude Code skill install", "Codex CLI skill install", "OpenClaw skill"]
+description: "Install ical and start managing your macOS Calendar from the terminal. Supports Homebrew, curl install, go install, and manual download on macOS."
+keywords: ["install ical macOS", "brew install ical", "homebrew ical", "macOS Calendar CLI install", "go install ical", "ical getting started", "EventKit CLI setup", "Claude Code skill install", "Codex CLI skill install", "OpenClaw skill"]
 weight: 1
 ---
 
@@ -15,7 +15,14 @@ ical uses cgo to compile native EventKit bindings directly into the binary. It d
 
 ## Installation
 
-### Quick install (recommended)
+### Homebrew
+
+```bash
+brew tap BRO3886/tap
+brew install ical
+```
+
+### Quick install
 
 ```bash
 curl -fsSL https://ical.sidv.dev/install | bash

--- a/website/themes/cal-docs/layouts/index.html
+++ b/website/themes/cal-docs/layouts/index.html
@@ -185,9 +185,9 @@
       <details class="faq-item scroll-reveal">
         <summary class="faq-question">How do I install ical?</summary>
         <div class="faq-answer">
-          <p>The fastest way is the install script:</p>
-          <pre><code>curl -fsSL https://ical.sidv.dev/install | bash</code></pre>
-          <p>Alternatively, if you have Go and Xcode CLT installed: <code>go install github.com/BRO3886/ical/cmd/ical@latest</code></p>
+          <p>The fastest way is via Homebrew:</p>
+          <pre><code>brew tap BRO3886/tap && brew install ical</code></pre>
+          <p>Or use the install script: <code>curl -fsSL https://ical.sidv.dev/install | bash</code></p>
         </div>
       </details>
 
@@ -236,7 +236,11 @@
     <p class="section-subtitle scroll-reveal">One command. No dependencies.</p>
     <div class="install-card scroll-reveal">
       <div class="install-tabs" role="tablist">
-        <button class="install-tab active" role="tab" aria-selected="true" data-tab="script">
+        <button class="install-tab active" role="tab" aria-selected="true" data-tab="brew">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M17 8l4 4-4 4"/><path d="M3 12h18"/></svg>
+          Homebrew
+        </button>
+        <button class="install-tab" role="tab" aria-selected="false" data-tab="script">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
           Script
         </button>
@@ -250,11 +254,27 @@
         </button>
       </div>
 
-      <div class="install-panel active" data-panel="script">
+      <div class="install-panel active" data-panel="brew">
         <div class="install-step">
           <div class="install-cmd-block">
             <div class="install-cmd-header">
               <span class="install-cmd-badge">Recommended</span>
+              <button class="install-copy-btn" data-copy="brew tap BRO3886/tap && brew install ical" aria-label="Copy">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+              </button>
+            </div>
+            <div class="install-cmd-body">
+              <span class="install-prompt">$</span>
+              <code>brew tap BRO3886/tap && brew install ical</code>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="install-panel" data-panel="script">
+        <div class="install-step">
+          <div class="install-cmd-block">
+            <div class="install-cmd-header">
               <button class="install-copy-btn" data-copy="curl -fsSL https://ical.sidv.dev/install | bash" aria-label="Copy">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
               </button>


### PR DESCRIPTION
Adds a Homebrew section as the first install method in Getting Started, using the `BRO3886/tap` tap. Removes the "recommended" label from the curl install since Homebrew is now the preferred method. Also updates the page description and keywords to include Homebrew.
