### PR TITLE
Auto-update Homebrew formula on release

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,77 @@
+name: Update Homebrew formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for release assets
+        run: sleep 30
+
+      - name: Get release info
+        id: release
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download and checksum
+        id: checksums
+        run: |
+          ARM_URL="https://github.com/BRO3886/ical/releases/download/${{ github.ref_name }}/ical-darwin-arm64.tar.gz"
+          AMD_URL="https://github.com/BRO3886/ical/releases/download/${{ github.ref_name }}/ical-darwin-amd64.tar.gz"
+          curl -sL "$ARM_URL" -o arm64.tar.gz
+          curl -sL "$AMD_URL" -o amd64.tar.gz
+          echo "arm64_sha=$(shasum -a 256 arm64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "amd64_sha=$(shasum -a 256 amd64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tap
+        uses: actions/checkout@v4
+        with:
+          repository: BRO3886/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          cat > homebrew-tap/Formula/ical.rb << 'FORMULA'
+          class Ical < Formula
+            desc "Fast, native macOS Calendar CLI built on go-eventkit"
+            homepage "https://github.com/BRO3886/ical"
+            version "${{ steps.release.outputs.version }}"
+            license "MIT"
+
+            depends_on :macos
+
+            on_arm do
+              url "https://github.com/BRO3886/ical/releases/download/${{ github.ref_name }}/ical-darwin-arm64.tar.gz"
+              sha256 "${{ steps.checksums.outputs.arm64_sha }}"
+            end
+
+            on_intel do
+              url "https://github.com/BRO3886/ical/releases/download/${{ github.ref_name }}/ical-darwin-amd64.tar.gz"
+              sha256 "${{ steps.checksums.outputs.amd64_sha }}"
+            end
+
+            def install
+              bin.install "ical"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/ical version")
+            end
+          end
+          FORMULA
+          sed -i 's/^          //' homebrew-tap/Formula/ical.rb
+
+      - name: Commit and push
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/ical.rb
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "feat: bump ical to ${{ steps.release.outputs.version }}"
+          git push

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -36,23 +36,27 @@ jobs:
 
       - name: Update formula
         run: |
-          cat > homebrew-tap/Formula/ical.rb << 'FORMULA'
+          VERSION="${{ steps.release.outputs.version }}"
+          TAG="${{ github.ref_name }}"
+          ARM_SHA="${{ steps.checksums.outputs.arm64_sha }}"
+          AMD_SHA="${{ steps.checksums.outputs.amd64_sha }}"
+          cat > homebrew-tap/Formula/ical.rb <<EOF
           class Ical < Formula
             desc "Fast, native macOS Calendar CLI built on go-eventkit"
             homepage "https://github.com/BRO3886/ical"
-            version "${{ steps.release.outputs.version }}"
+            version "${VERSION}"
             license "MIT"
 
             depends_on :macos
 
             on_arm do
-              url "https://github.com/BRO3886/ical/releases/download/${{ github.ref_name }}/ical-darwin-arm64.tar.gz"
-              sha256 "${{ steps.checksums.outputs.arm64_sha }}"
+              url "https://github.com/BRO3886/ical/releases/download/${TAG}/ical-darwin-arm64.tar.gz"
+              sha256 "${ARM_SHA}"
             end
 
             on_intel do
-              url "https://github.com/BRO3886/ical/releases/download/${{ github.ref_name }}/ical-darwin-amd64.tar.gz"
-              sha256 "${{ steps.checksums.outputs.amd64_sha }}"
+              url "https://github.com/BRO3886/ical/releases/download/${TAG}/ical-darwin-amd64.tar.gz"
+              sha256 "${AMD_SHA}"
             end
 
             def install
@@ -60,10 +64,10 @@ jobs:
             end
 
             test do
-              assert_match version.to_s, shell_output("#{bin}/ical version")
+              assert_match version.to_s, shell_output("\#{bin}/ical version")
             end
           end
-          FORMULA
+          EOF
           sed -i 's/^          //' homebrew-tap/Formula/ical.rb
 
       - name: Commit and push


### PR DESCRIPTION
Adds a GitHub Actions workflow that triggers on release publication and automatically updates the Homebrew formula in `BRO3886/homebrew-tap`.

## What it does
- Waits 30s for release assets to be available
- Downloads the darwin-arm64 and darwin-amd64 tarballs and computes their SHA256s
- Checks out the tap repo using `TAP_GITHUB_TOKEN`
- Overwrites `Formula/ical.rb` with the new version, URLs, and checksums
- Commits and pushes if there are changes

## Required secret
Add `TAP_GITHUB_TOKEN` to `BRO3886/ical` repo secrets — a PAT with `contents: write` access to `BRO3886/homebrew-tap`.
