### PR TITLE
Add date column to event tables and trim whitespace on exclude-calendar

### DIFF
--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -90,19 +90,7 @@ func listEvents(from, to time.Time) error {
 		events = filtered
 	}
 
-	if len(listExcludeCalendar) > 0 {
-		excluded := make(map[string]bool, len(listExcludeCalendar))
-		for _, c := range listExcludeCalendar {
-			excluded[normalizeCalendarName(c)] = true
-		}
-		filtered := make([]calendar.Event, 0, len(events))
-		for _, e := range events {
-			if !excluded[normalizeCalendarName(e.Calendar)] {
-				filtered = append(filtered, e)
-			}
-		}
-		events = filtered
-	}
+	events = filterExcludedCalendars(events, listExcludeCalendar)
 
 	sortEvents(events, listSort)
 
@@ -153,6 +141,34 @@ func sortEvents(events []calendar.Event, sortBy string) {
 // --exclude-calendar matches regardless of accidental padding or casing.
 func normalizeCalendarName(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// filterExcludedCalendars drops events whose calendar name matches any
+// of the user-supplied names after normalization. Exclude entries that
+// normalize to the empty string are ignored so a whitespace-only flag
+// value cannot silently filter events with an empty Calendar field.
+func filterExcludedCalendars(events []calendar.Event, exclude []string) []calendar.Event {
+	if len(exclude) == 0 {
+		return events
+	}
+	excluded := make(map[string]bool, len(exclude))
+	for _, c := range exclude {
+		normalized := normalizeCalendarName(c)
+		if normalized == "" {
+			continue
+		}
+		excluded[normalized] = true
+	}
+	if len(excluded) == 0 {
+		return events
+	}
+	filtered := make([]calendar.Event, 0, len(events))
+	for _, e := range events {
+		if !excluded[normalizeCalendarName(e.Calendar)] {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
 }
 
 func startOfDay(t time.Time) time.Time {

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -93,11 +93,11 @@ func listEvents(from, to time.Time) error {
 	if len(listExcludeCalendar) > 0 {
 		excluded := make(map[string]bool, len(listExcludeCalendar))
 		for _, c := range listExcludeCalendar {
-			excluded[strings.ToLower(c)] = true
+			excluded[normalizeCalendarName(c)] = true
 		}
 		filtered := make([]calendar.Event, 0, len(events))
 		for _, e := range events {
-			if !excluded[strings.ToLower(e.Calendar)] {
+			if !excluded[normalizeCalendarName(e.Calendar)] {
 				filtered = append(filtered, e)
 			}
 		}
@@ -147,6 +147,12 @@ func sortEvents(events []calendar.Event, sortBy string) {
 			return events[i].StartDate.Before(events[j].StartDate)
 		})
 	}
+}
+
+// normalizeCalendarName trims surrounding whitespace and lowercases so
+// --exclude-calendar matches regardless of accidental padding or casing.
+func normalizeCalendarName(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }
 
 func startOfDay(t time.Time) time.Time {

--- a/cmd/ical/commands/list_test.go
+++ b/cmd/ical/commands/list_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import "testing"
+
+func TestNormalizeCalendarName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "Work", "work"},
+		{"already lowercase", "work", "work"},
+		{"leading space", "  Work", "work"},
+		{"trailing space", "Work   ", "work"},
+		{"both sides padded", "  Work  ", "work"},
+		{"tab padded", "\tWork\t", "work"},
+		{"internal spaces preserved", "Holidays in India", "holidays in india"},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeCalendarName(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeCalendarName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ical/commands/list_test.go
+++ b/cmd/ical/commands/list_test.go
@@ -1,6 +1,10 @@
 package commands
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+)
 
 func TestNormalizeCalendarName(t *testing.T) {
 	tests := []struct {
@@ -24,6 +28,60 @@ func TestNormalizeCalendarName(t *testing.T) {
 			got := normalizeCalendarName(tt.in)
 			if got != tt.want {
 				t.Errorf("normalizeCalendarName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterExcludedCalendars(t *testing.T) {
+	events := []calendar.Event{
+		{Title: "A", Calendar: "Work"},
+		{Title: "B", Calendar: "Personal"},
+		{Title: "C", Calendar: ""},
+		{Title: "D", Calendar: "  Holidays  "},
+	}
+
+	titles := func(evs []calendar.Event) []string {
+		out := make([]string, len(evs))
+		for i, e := range evs {
+			out[i] = e.Title
+		}
+		return out
+	}
+
+	eq := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	tests := []struct {
+		name    string
+		exclude []string
+		want    []string
+	}{
+		{"nil exclude keeps everything", nil, []string{"A", "B", "C", "D"}},
+		{"empty slice keeps everything", []string{}, []string{"A", "B", "C", "D"}},
+		{"exact name match", []string{"Work"}, []string{"B", "C", "D"}},
+		{"case insensitive match", []string{"PERSONAL"}, []string{"A", "C", "D"}},
+		{"padded flag matches padded calendar name", []string{"Holidays"}, []string{"A", "B", "C"}},
+		{"multiple excludes", []string{"Work", "Personal"}, []string{"C", "D"}},
+		{"whitespace-only exclude does not drop empty-calendar events", []string{"   "}, []string{"A", "B", "C", "D"}},
+		{"whitespace-only mixed with valid exclude applies only the valid one", []string{"   ", "Work"}, []string{"B", "C", "D"}},
+		{"unknown exclude is a no-op", []string{"Nonexistent"}, []string{"A", "B", "C", "D"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := titles(filterExcludedCalendars(events, tt.exclude))
+			if !eq(got, tt.want) {
+				t.Errorf("titles = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -96,14 +96,21 @@ func printEventsTable(events []calendar.Event, w io.Writer) {
 	t := tablewriter.NewTable(w,
 		tablewriter.WithConfig(tablewriter.Config{
 			Header: tw.CellConfig{Formatting: tw.CellFormatting{Alignment: tw.AlignCenter}},
-			Row:    tw.CellConfig{Formatting: tw.CellFormatting{Alignment: tw.AlignLeft}},
+			Row: tw.CellConfig{
+				Formatting: tw.CellFormatting{Alignment: tw.AlignLeft},
+				Merging: tw.CellMerging{
+					Mode:          tw.MergeVertical,
+					ByColumnIndex: tw.Mapper[int, bool]{1: true},
+				},
+			},
 		}),
 	)
-	t.Header("#", "Time", "Title", "Calendar", "Location", "Duration")
+	t.Header("#", "Date", "Time", "Title", "Calendar", "Location", "Duration")
 
 	for i, e := range events {
 		start := localizeTime(e.StartDate, e.TimeZone)
 		end := localizeTime(e.EndDate, e.TimeZone)
+		dateStr := eventDateLabel(start)
 		timeStr := dateparser.FormatTimeRange(start, end, e.AllDay)
 		title := truncate(e.Title, 40)
 		loc := truncate(e.Location, 25)
@@ -117,7 +124,7 @@ func printEventsTable(events []calendar.Event, w io.Writer) {
 			title = title + " " + color.HiCyanString("↻")
 		}
 
-		t.Append(fmt.Sprintf("%d", i+1), timeStr, title, calName, loc, dur)
+		t.Append(fmt.Sprintf("%d", i+1), dateStr, timeStr, title, calName, loc, dur)
 	}
 
 	t.Render()
@@ -518,6 +525,14 @@ func formatAlertDuration(d time.Duration) string {
 // localizeTime converts a time to the system's local timezone.
 func localizeTime(t time.Time, _ string) time.Time {
 	return t.In(time.Local)
+}
+
+// eventDateLabel returns the date-column label for an event row.
+// The input must already be localized — the label uses whatever
+// location is on t, which is what makes same-instant events group
+// under the viewer's local day rather than UTC.
+func eventDateLabel(t time.Time) string {
+	return t.Format("Mon 02 Jan")
 }
 
 // localizeTimeInZone converts a time to the event's own timezone.

--- a/internal/ui/output_test.go
+++ b/internal/ui/output_test.go
@@ -240,6 +240,44 @@ func TestLocalizeTimeInZone(t *testing.T) {
 	})
 }
 
+func TestEventDateLabel(t *testing.T) {
+	// UTC 15:00 on Sunday 19 Apr 2026. In BST (UTC+1) this is 16:00 Sun;
+	// in UTC-negative zones it still falls on Apr 19. The label must reflect
+	// whatever location the input carries — the caller localizes upstream.
+	utcTime := time.Date(2026, 4, 19, 15, 0, 0, 0, time.UTC)
+
+	bst := mustLoadLocation("Europe/London") // BST in April = UTC+1
+	est := mustLoadLocation("America/New_York") // EDT in April = UTC-4
+	ist := mustLoadLocation("Asia/Kolkata")   // IST = UTC+5:30
+
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"UTC 15:00 viewed in BST stays on Sunday", utcTime.In(bst), "Sun 19 Apr"},
+		{"UTC 15:00 viewed in EDT stays on Sunday", utcTime.In(est), "Sun 19 Apr"},
+		{"UTC 19:30 Sun viewed in IST rolls into Monday",
+			time.Date(2026, 4, 19, 19, 30, 0, 0, time.UTC).In(ist),
+			"Mon 20 Apr"},
+		{"UTC 23:30 Sat viewed in BST rolls into Sunday",
+			time.Date(2026, 4, 18, 23, 30, 0, 0, time.UTC).In(bst),
+			"Sun 19 Apr"},
+		{"UTC 03:30 Sun viewed in EDT stays on Saturday",
+			time.Date(2026, 4, 19, 3, 30, 0, 0, time.UTC).In(est),
+			"Sat 18 Apr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := eventDateLabel(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTruncate(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary

Two fixes bundled together since they both touch list output and are small.

### Date column on event tables (closes #18)

Multi-day listings previously had no way to tell which day a row belonged to — rows showed `HH:MM - HH:MM` with no date context, so a Sunday 16:00 event looked identical to a Monday 16:00 event. The original reporter dug into the code and confirmed the timezone conversion was correct; the real issue was purely a UX one. Two follow-up +1s on the same thread.

Added a `Date` column with vertical merge on identical adjacent cells, so the date prints only on day transitions:

```
┌────┬────────────┬─────────────────┬──────────────────┬──────────┐
│ #  │    DATE    │      TIME       │      TITLE       │ DURATION │
├────┼────────────┼─────────────────┼──────────────────┼──────────┤
│ 1  │ Sat 18 Apr │ 06:40 - 09:30   │ 6124  DEL1-IXB   │ 2h 50m   │
│ 2  │            │ 10:05 - 12:50   │ 6125  IXB-DEL1   │ 2h 45m   │
│ 3  │ Sun 19 Apr │ 03:40 - 06:45   │ 5322  DEL3-PNQ   │ 3h 5m    │
└────┴────────────┴─────────────────┴──────────────────┴──────────┘
```

Date label is built from the already-localized time, so viewers in any timezone see correct local-day grouping.

Row numbers stay sequential across the whole listing — `ical show 3` still works against `~/.ical-last-list`, no behaviour change.

Extracted `eventDateLabel(time.Time) string` and added a focused test covering BST, EDT, IST boundary-day cases so the local-day semantics can't silently regress.

JSON and plain outputs unchanged.

### Trim whitespace on `--exclude-calendar` (refs #20)

Couldn't reproduce the reported silent-failure locally — filtering works for single, multi, and all-calendar excludes. Most likely cause is accidental whitespace padding on the calendar name (either from the user's input or from the EventKit-returned `Calendar` field). Added a `normalizeCalendarName` helper that trims + lowercases both sides so padding stops masking the match.

Not closing #20 in case the reporter's actual issue turns out to be something else — leaving it as a defensive fix that covers the most likely cause.

## Test plan

- [x] `go test ./...` — 285 pass (was 279 before the added date-label and trim tests)
- [x] Smoke tested `ical list`, `ical today`, `ical upcoming`, `ical search` with and without `--exclude-calendar`
- [x] Smoke tested `--exclude-calendar "  Gatech  "` — padded name now matches
- [x] Smoke tested excluding all 11 calendars — returns `No events found.` cleanly
- [x] Confirmed JSON output unchanged
