### PR TITLE
Add --attendee flag for filtering events by attendee or organizer

### DIFF
--- a/cmd/ical/commands/attendee_test.go
+++ b/cmd/ical/commands/attendee_test.go
@@ -87,8 +87,29 @@ func TestAttendeeMatches(t *testing.T) {
 					{Name: "sarah smith", Email: "sarah@example.com"},
 				},
 			},
-			query: "sarah",
+			query: "SARAH",
 			want:  true,
+		},
+		{
+			name: "padded query is trimmed before matching",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+			},
+			query: "  sarah  ",
+			want:  true,
+		},
+		{
+			name: "whitespace-only query does not match anything",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+				Organizer: "Bob Jones",
+			},
+			query: "   ",
+			want:  false,
 		},
 	}
 

--- a/cmd/ical/commands/attendee_test.go
+++ b/cmd/ical/commands/attendee_test.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+)
+
+func TestAttendeeMatches(t *testing.T) {
+	tests := []struct {
+		name  string
+		event calendar.Event
+		query string
+		want  bool
+	}{
+		{
+			name: "name match case insensitive",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+			},
+			query: "sarah",
+			want:  true,
+		},
+		{
+			name: "email match",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Bob Jones", Email: "bob@example.com"},
+				},
+			},
+			query: "bob@example",
+			want:  true,
+		},
+		{
+			name: "organizer match",
+			event: calendar.Event{
+				Organizer: "Alice Johnson",
+			},
+			query: "alice",
+			want:  true,
+		},
+		{
+			name: "substring match",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+			},
+			query: "smi",
+			want:  true,
+		},
+		{
+			name:  "no attendees returns false",
+			event: calendar.Event{},
+			query: "anyone",
+			want:  false,
+		},
+		{
+			name: "no match returns false",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Sarah Smith", Email: "sarah@example.com"},
+				},
+				Organizer: "Bob Jones",
+			},
+			query: "charlie",
+			want:  false,
+		},
+		{
+			name: "multiple attendees one matches",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "Alice Brown", Email: "alice@example.com"},
+					{Name: "Bob Green", Email: "bob@example.com"},
+					{Name: "Carol White", Email: "carol@example.com"},
+				},
+			},
+			query: "bob",
+			want:  true,
+		},
+		{
+			name: "uppercase query matches lowercase name",
+			event: calendar.Event{
+				Attendees: []calendar.Attendee{
+					{Name: "sarah smith", Email: "sarah@example.com"},
+				},
+			},
+			query: "sarah",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := attendeeMatches(tt.event, tt.query)
+			if got != tt.want {
+				t.Errorf("attendeeMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -22,6 +22,7 @@ var (
 	listSort            string
 	listLimit           int
 	listExcludeCalendar []string
+	listAttendee        string
 )
 
 var listCmd = &cobra.Command{
@@ -64,6 +65,7 @@ func init() {
 	listCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	listCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	listCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
+	listCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(listCmd)
 }
@@ -98,6 +100,17 @@ func listEvents(from, to time.Time) error {
 		filtered := make([]calendar.Event, 0, len(events))
 		for _, e := range events {
 			if !excluded[strings.ToLower(e.Calendar)] {
+				filtered = append(filtered, e)
+			}
+		}
+		events = filtered
+	}
+
+	if listAttendee != "" {
+		query := strings.ToLower(listAttendee)
+		filtered := make([]calendar.Event, 0, len(events))
+		for _, e := range events {
+			if attendeeMatches(e, query) {
 				filtered = append(filtered, e)
 			}
 		}
@@ -161,4 +174,22 @@ func endOfDayIfMidnight(t time.Time) time.Time {
 		return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, t.Location())
 	}
 	return t
+}
+
+// attendeeMatches returns true if any attendee name/email or the organizer
+// matches the query (case-insensitive substring). The query must already be
+// lowercased by the caller.
+func attendeeMatches(e calendar.Event, query string) bool {
+	for _, att := range e.Attendees {
+		if strings.Contains(strings.ToLower(att.Name), query) {
+			return true
+		}
+		if strings.Contains(strings.ToLower(att.Email), query) {
+			return true
+		}
+	}
+	if e.Organizer != "" && strings.Contains(strings.ToLower(e.Organizer), query) {
+		return true
+	}
+	return false
 }

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -65,7 +65,7 @@ func init() {
 	listCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	listCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	listCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
-	listCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
+	listCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
 
 	rootCmd.AddCommand(listCmd)
 }
@@ -107,10 +107,9 @@ func listEvents(from, to time.Time) error {
 	}
 
 	if listAttendee != "" {
-		query := strings.ToLower(listAttendee)
 		filtered := make([]calendar.Event, 0, len(events))
 		for _, e := range events {
-			if attendeeMatches(e, query) {
+			if attendeeMatches(e, listAttendee) {
 				filtered = append(filtered, e)
 			}
 		}
@@ -177,18 +176,22 @@ func endOfDayIfMidnight(t time.Time) time.Time {
 }
 
 // attendeeMatches returns true if any attendee name/email or the organizer
-// matches the query (case-insensitive substring). The query must already be
-// lowercased by the caller.
+// contains the query as a case-insensitive substring. Whitespace around the
+// query is trimmed so shell-quoted inputs like " alice" still match.
 func attendeeMatches(e calendar.Event, query string) bool {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return false
+	}
 	for _, att := range e.Attendees {
-		if strings.Contains(strings.ToLower(att.Name), query) {
+		if strings.Contains(strings.ToLower(att.Name), q) {
 			return true
 		}
-		if strings.Contains(strings.ToLower(att.Email), query) {
+		if strings.Contains(strings.ToLower(att.Email), q) {
 			return true
 		}
 	}
-	if e.Organizer != "" && strings.Contains(strings.ToLower(e.Organizer), query) {
+	if e.Organizer != "" && strings.Contains(strings.ToLower(e.Organizer), q) {
 		return true
 	}
 	return false

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -16,6 +16,7 @@ var (
 	searchTo       string
 	searchCalendar string
 	searchLimit    int
+	searchAttendee string
 )
 
 var searchCmd = &cobra.Command{
@@ -61,6 +62,17 @@ var searchCmd = &cobra.Command{
 			return fmt.Errorf("failed to search events: %w", err)
 		}
 
+		if searchAttendee != "" {
+			attendeeQuery := strings.ToLower(searchAttendee)
+			filtered := make([]calendar.Event, 0, len(events))
+			for _, e := range events {
+				if attendeeMatches(e, attendeeQuery) {
+					filtered = append(filtered, e)
+				}
+			}
+			events = filtered
+		}
+
 		if searchLimit > 0 && len(events) > searchLimit {
 			events = events[:searchLimit]
 		}
@@ -75,6 +87,7 @@ func init() {
 	searchCmd.Flags().StringVarP(&searchTo, "to", "t", "", "End of search range (default: 30 days ahead)")
 	searchCmd.Flags().StringVarP(&searchCalendar, "calendar", "c", "", "Filter by calendar")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 0, "Max results")
+	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -63,10 +63,9 @@ var searchCmd = &cobra.Command{
 		}
 
 		if searchAttendee != "" {
-			attendeeQuery := strings.ToLower(searchAttendee)
 			filtered := make([]calendar.Event, 0, len(events))
 			for _, e := range events {
-				if attendeeMatches(e, attendeeQuery) {
+				if attendeeMatches(e, searchAttendee) {
 					filtered = append(filtered, e)
 				}
 			}

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -87,7 +87,7 @@ func init() {
 	searchCmd.Flags().StringVarP(&searchTo, "to", "t", "", "End of search range (default: 30 days ahead)")
 	searchCmd.Flags().StringVarP(&searchCalendar, "calendar", "c", "", "Filter by calendar")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 0, "Max results")
-	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee name or email")
+	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
 
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/ical/commands/today.go
+++ b/cmd/ical/commands/today.go
@@ -26,7 +26,7 @@ func init() {
 	todayCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	todayCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	todayCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
-	todayCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
+	todayCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
 
 	rootCmd.AddCommand(todayCmd)
 }

--- a/cmd/ical/commands/today.go
+++ b/cmd/ical/commands/today.go
@@ -26,6 +26,7 @@ func init() {
 	todayCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	todayCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	todayCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
+	todayCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(todayCmd)
 }

--- a/cmd/ical/commands/upcoming.go
+++ b/cmd/ical/commands/upcoming.go
@@ -30,6 +30,7 @@ func init() {
 	upcomingCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	upcomingCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	upcomingCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
+	upcomingCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
 
 	rootCmd.AddCommand(upcomingCmd)
 }

--- a/cmd/ical/commands/upcoming.go
+++ b/cmd/ical/commands/upcoming.go
@@ -30,7 +30,7 @@ func init() {
 	upcomingCmd.Flags().StringVar(&listSort, "sort", "start", "Sort by: start, end, title, calendar")
 	upcomingCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	upcomingCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
-	upcomingCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee name or email")
+	upcomingCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
 
 	rootCmd.AddCommand(upcomingCmd)
 }


### PR DESCRIPTION
## Summary

Adds an `--attendee` / `-a` flag to `list`, `today`, `upcoming`, and `search` for filtering events by attendee or organizer (case-insensitive substring match on name or email).

Originally authored by @rtblair in #19. Re-opening from this repo's branch so CI/merge can run against origin directly.

### Original work (by @rtblair)

- Register `--attendee` / `-a` on all four list-producing commands
- `attendeeMatches()` helper doing substring match against attendee name/email and organizer
- Unit tests covering attendee/organizer matching

### Follow-ups in this PR

Addresses the Copilot review comments on #19:

- Move `ToLower` + `TrimSpace` inside `attendeeMatches` so the helper is truly case-insensitive regardless of caller behaviour. Drops the pre-lowercasing at call sites in `list.go` and `search.go`.
- Update `--attendee` help text on `list`, `today`, and `upcoming` to mention organizer matching (was already fixed on `search` by the autofix commit).
- Fix the misleading "uppercase query matches lowercase name" test to actually pass an uppercase query.
- Add test cases for padded queries (`"  sarah  "`) and whitespace-only queries (should not match anything).

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Smoke tested all four commands (`list`, `today`, `upcoming`, `search`) against a real calendar with attendee data:
  - Lowercase query → matches
  - Uppercase query → matches (case-insensitive)
  - Padded `"  name  "` → matches (trim)
  - Organizer substring → matches
  - Nonexistent name → `No events found.`
