### PR TITLE
Add --no-recurring flag to hide recurring events

### DIFF
--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/BRO3886/go-eventkit/calendar"
 	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/BRO3886/ical/internal/ui"
-	"github.com/BRO3886/go-eventkit/calendar"
 	"github.com/spf13/cobra"
 )
 
@@ -161,8 +161,23 @@ func normalizeCalendarName(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }
 
-// filterRecurring returns only the non-recurring events.
+// filterRecurring returns only the non-recurring events. The input slice
+// is returned as-is when nothing needs to be dropped so the common case
+// (no recurring events at all) avoids an allocation.
 func filterRecurring(events []calendar.Event) []calendar.Event {
+	if len(events) == 0 {
+		return events
+	}
+	hasRecurring := false
+	for _, e := range events {
+		if e.Recurring {
+			hasRecurring = true
+			break
+		}
+	}
+	if !hasRecurring {
+		return events
+	}
 	filtered := make([]calendar.Event, 0, len(events))
 	for _, e := range events {
 		if !e.Recurring {

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -23,6 +23,7 @@ var (
 	listLimit           int
 	listExcludeCalendar []string
 	listAttendee        string
+	listNoRecurring     bool
 )
 
 var listCmd = &cobra.Command{
@@ -66,6 +67,7 @@ func init() {
 	listCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	listCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
 	listCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
+	listCmd.Flags().BoolVar(&listNoRecurring, "no-recurring", false, "Hide recurring events")
 
 	rootCmd.AddCommand(listCmd)
 }
@@ -93,6 +95,10 @@ func listEvents(from, to time.Time) error {
 	}
 
 	events = filterExcludedCalendars(events, listExcludeCalendar)
+
+	if listNoRecurring {
+		events = filterRecurring(events)
+	}
 
 	if listAttendee != "" {
 		filtered := make([]calendar.Event, 0, len(events))
@@ -153,6 +159,17 @@ func sortEvents(events []calendar.Event, sortBy string) {
 // --exclude-calendar matches regardless of accidental padding or casing.
 func normalizeCalendarName(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// filterRecurring returns only the non-recurring events.
+func filterRecurring(events []calendar.Event) []calendar.Event {
+	filtered := make([]calendar.Event, 0, len(events))
+	for _, e := range events {
+		if !e.Recurring {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
 }
 
 // filterExcludedCalendars drops events whose calendar name matches any

--- a/cmd/ical/commands/list_test.go
+++ b/cmd/ical/commands/list_test.go
@@ -33,6 +33,34 @@ func TestNormalizeCalendarName(t *testing.T) {
 	}
 }
 
+func TestFilterRecurring(t *testing.T) {
+	events := []calendar.Event{
+		{Title: "A", Recurring: false},
+		{Title: "B", Recurring: true},
+		{Title: "C", Recurring: false},
+		{Title: "D", Recurring: true},
+	}
+
+	got := filterRecurring(events)
+	if len(got) != 2 || got[0].Title != "A" || got[1].Title != "C" {
+		t.Errorf("filterRecurring dropped the wrong events, got %+v", got)
+	}
+
+	if len(filterRecurring(nil)) != 0 {
+		t.Error("filterRecurring(nil) should return empty slice")
+	}
+
+	allRecurring := []calendar.Event{{Title: "X", Recurring: true}}
+	if len(filterRecurring(allRecurring)) != 0 {
+		t.Error("all-recurring input should yield empty output")
+	}
+
+	noneRecurring := []calendar.Event{{Title: "Y", Recurring: false}}
+	if len(filterRecurring(noneRecurring)) != 1 {
+		t.Error("no-recurring input should pass through unchanged")
+	}
+}
+
 func TestFilterExcludedCalendars(t *testing.T) {
 	events := []calendar.Event{
 		{Title: "A", Calendar: "Work"},

--- a/cmd/ical/commands/list_test.go
+++ b/cmd/ical/commands/list_test.go
@@ -34,31 +34,51 @@ func TestNormalizeCalendarName(t *testing.T) {
 }
 
 func TestFilterRecurring(t *testing.T) {
-	events := []calendar.Event{
-		{Title: "A", Recurring: false},
-		{Title: "B", Recurring: true},
-		{Title: "C", Recurring: false},
-		{Title: "D", Recurring: true},
-	}
+	t.Run("drops only recurring entries", func(t *testing.T) {
+		events := []calendar.Event{
+			{Title: "A", Recurring: false},
+			{Title: "B", Recurring: true},
+			{Title: "C", Recurring: false},
+			{Title: "D", Recurring: true},
+		}
+		got := filterRecurring(events)
+		if len(got) != 2 || got[0].Title != "A" || got[1].Title != "C" {
+			t.Errorf("wrong events retained, got %+v", got)
+		}
+	})
 
-	got := filterRecurring(events)
-	if len(got) != 2 || got[0].Title != "A" || got[1].Title != "C" {
-		t.Errorf("filterRecurring dropped the wrong events, got %+v", got)
-	}
+	t.Run("nil input returns nil without panicking", func(t *testing.T) {
+		if got := filterRecurring(nil); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
 
-	if len(filterRecurring(nil)) != 0 {
-		t.Error("filterRecurring(nil) should return empty slice")
-	}
+	t.Run("empty slice returns same empty slice", func(t *testing.T) {
+		in := []calendar.Event{}
+		got := filterRecurring(in)
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %+v", got)
+		}
+	})
 
-	allRecurring := []calendar.Event{{Title: "X", Recurring: true}}
-	if len(filterRecurring(allRecurring)) != 0 {
-		t.Error("all-recurring input should yield empty output")
-	}
+	t.Run("all-recurring input yields empty result", func(t *testing.T) {
+		in := []calendar.Event{{Title: "X", Recurring: true}, {Title: "Y", Recurring: true}}
+		if got := filterRecurring(in); len(got) != 0 {
+			t.Errorf("expected empty, got %+v", got)
+		}
+	})
 
-	noneRecurring := []calendar.Event{{Title: "Y", Recurring: false}}
-	if len(filterRecurring(noneRecurring)) != 1 {
-		t.Error("no-recurring input should pass through unchanged")
-	}
+	t.Run("no-recurring input passes through as the same slice", func(t *testing.T) {
+		in := []calendar.Event{{Title: "Y", Recurring: false}, {Title: "Z", Recurring: false}}
+		got := filterRecurring(in)
+		if len(got) != len(in) {
+			t.Fatalf("expected pass-through of %d events, got %d", len(in), len(got))
+		}
+		// Fast path: should return the same backing slice, not a copy.
+		if &got[0] != &in[0] {
+			t.Error("expected pass-through to return the input slice, got a copy")
+		}
+	})
 }
 
 func TestFilterExcludedCalendars(t *testing.T) {

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/BRO3886/go-eventkit/calendar"
 	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/BRO3886/ical/internal/ui"
-	"github.com/BRO3886/go-eventkit/calendar"
 	"github.com/spf13/cobra"
 )
 
 var (
-	searchFrom     string
-	searchTo       string
-	searchCalendar string
+	searchFrom        string
+	searchTo          string
+	searchCalendar    string
 	searchLimit       int
 	searchAttendee    string
 	searchNoRecurring bool

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -15,8 +15,9 @@ var (
 	searchFrom     string
 	searchTo       string
 	searchCalendar string
-	searchLimit    int
-	searchAttendee string
+	searchLimit       int
+	searchAttendee    string
+	searchNoRecurring bool
 )
 
 var searchCmd = &cobra.Command{
@@ -72,6 +73,10 @@ var searchCmd = &cobra.Command{
 			events = filtered
 		}
 
+		if searchNoRecurring {
+			events = filterRecurring(events)
+		}
+
 		if searchLimit > 0 && len(events) > searchLimit {
 			events = events[:searchLimit]
 		}
@@ -87,6 +92,7 @@ func init() {
 	searchCmd.Flags().StringVarP(&searchCalendar, "calendar", "c", "", "Filter by calendar")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 0, "Max results")
 	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
+	searchCmd.Flags().BoolVar(&searchNoRecurring, "no-recurring", false, "Hide recurring events")
 
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/ical/commands/today.go
+++ b/cmd/ical/commands/today.go
@@ -27,6 +27,7 @@ func init() {
 	todayCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	todayCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
 	todayCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
+	todayCmd.Flags().BoolVar(&listNoRecurring, "no-recurring", false, "Hide recurring events")
 
 	rootCmd.AddCommand(todayCmd)
 }

--- a/cmd/ical/commands/upcoming.go
+++ b/cmd/ical/commands/upcoming.go
@@ -31,6 +31,7 @@ func init() {
 	upcomingCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Max events to display")
 	upcomingCmd.Flags().StringArrayVar(&listExcludeCalendar, "exclude-calendar", nil, "Exclude calendars by name (repeatable)")
 	upcomingCmd.Flags().StringVarP(&listAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
+	upcomingCmd.Flags().BoolVar(&listNoRecurring, "no-recurring", false, "Hide recurring events")
 
 	rootCmd.AddCommand(upcomingCmd)
 }


### PR DESCRIPTION
## Summary

Closes #14.

Adds a `--no-recurring` flag on `list`, `today`, `upcoming`, and `search` that drops recurring events from the output. Matches the ask from @laukondrup — lets users focus on one-off events without grepping past repeated meetings.

Extracted a shared `filterRecurring` helper alongside the existing `filterExcludedCalendars` so the behaviour is testable in one place and stays consistent between the list path and the search path.

Naming note: went with `--no-recurring` over `--hide-recurring` to match the Unix convention for exclude-style flags (`--no-color`, `--no-cache`). Kept it as a simple boolean rather than a three-state filter since the ask was specifically "filter those out".

## Test plan

- [x] `go test ./...` passes (added `TestFilterRecurring` covering mixed, all-recurring, all-non-recurring, and nil inputs)
- [x] `go vet ./...` clean
- [x] Smoke tested on a real calendar:
  - `list --no-recurring` drops all rows marked with ↻ (5 → 0)
  - `today --no-recurring` same
  - `upcoming --no-recurring` same
  - `search <query> --no-recurring` same
  - Help text shows `--no-recurring   Hide recurring events` on all four commands
