### PR TITLE
Document --attendee and --no-recurring flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ ical list -c Work -f today -t "in 7 days"
 # Exclude calendars
 ical upcoming --exclude-calendar Birthdays --exclude-calendar "Holidays in India"
 
+# Filter by attendee or organizer (case-insensitive substring match)
+ical list -f today -t "in 14 days" --attendee alice
+
+# Hide recurring events — focus on one-off meetings
+ical upcoming -d 7 --no-recurring
+
 # Search with date range
 ical search "meeting" -f "1 month ago" -t "in 1 month"
 

--- a/skills/ical-cli/SKILL.md
+++ b/skills/ical-cli/SKILL.md
@@ -266,6 +266,21 @@ ical calendars -o json | jq -r '.[] | "\(.id) \(.title)"'
 **Calendar JSON fields**: `id`, `title`, `type`, `color`, `source`, `readOnly`
 **Event JSON fields**: `id`, `title`, `start_date`, `end_date`, `calendar`, `calendar_id`, `location`, `notes`, `url`, `all_day`, `recurrence`, `alerts`
 
+### Filtering the agenda
+
+```bash
+# Hide recurring events (standups, recurring 1:1s) — focus on one-off meetings
+ical upcoming --days 7 --no-recurring
+
+# Find events involving a specific person (matches attendee name, email, or organizer)
+ical list --from today --to "in 14 days" --attendee alice
+
+# Skip noisy calendars from the listing
+ical today --exclude-calendar "US Holidays" --exclude-calendar Birthdays
+```
+
+`--attendee` is case-insensitive substring matching against attendee names/emails and the organizer. `--no-recurring` drops events whose `recurring` JSON field is true. Both flags are available on `list`, `today`, `upcoming`, and `search`.
+
 ### Backup and restore
 
 ```bash

--- a/skills/ical-cli/references/commands.md
+++ b/skills/ical-cli/references/commands.md
@@ -78,17 +78,19 @@ ical ls --from "mar 1" --to "mar 31" --all-day
 ical list --from today --to "in 30 days" --exclude-calendar Birthdays -o json
 ```
 
-| Flag                 | Short | Description                               | Default         |
-| -------------------- | ----- | ----------------------------------------- | --------------- |
-| `--from`             | `-f`  | Start date (natural language or ISO 8601) | Today           |
-| `--to`               | `-t`  | End date (natural language or ISO 8601)   | From + 24 hours |
-| `--calendar`         | `-c`  | Filter by calendar name                   | All calendars   |
-| `--calendar-id`      | —     | Filter by calendar ID                     | —               |
-| `--search`           | `-s`  | Search title, location, notes             | —               |
-| `--all-day`          | —     | Show only all-day events                  | false           |
-| `--sort`             | —     | Sort by: start, end, title, calendar      | start           |
-| `--limit`            | `-n`  | Max events to display (0 = unlimited)     | 0               |
-| `--exclude-calendar` | —     | Exclude calendars by name (repeatable)    | —               |
+| Flag                 | Short | Description                                     | Default         |
+| -------------------- | ----- | ----------------------------------------------- | --------------- |
+| `--from`             | `-f`  | Start date (natural language or ISO 8601)       | Today           |
+| `--to`               | `-t`  | End date (natural language or ISO 8601)         | From + 24 hours |
+| `--calendar`         | `-c`  | Filter by calendar name                         | All calendars   |
+| `--calendar-id`      | —     | Filter by calendar ID                           | —               |
+| `--search`           | `-s`  | Search title, location, notes                   | —               |
+| `--all-day`          | —     | Show only all-day events                        | false           |
+| `--sort`             | —     | Sort by: start, end, title, calendar            | start           |
+| `--limit`            | `-n`  | Max events to display (0 = unlimited)           | 0               |
+| `--exclude-calendar` | —     | Exclude calendars by name (repeatable)          | —               |
+| `--attendee`         | `-a`  | Filter by attendee or organizer name/email      | —               |
+| `--no-recurring`     | —     | Hide recurring events                           | false           |
 
 Aliases: `ls`, `events`
 
@@ -105,15 +107,17 @@ ical today -o json
 ical today --exclude-calendar Birthdays
 ```
 
-| Flag                 | Short | Description                            | Default       |
-| -------------------- | ----- | -------------------------------------- | ------------- |
-| `--calendar`         | `-c`  | Filter by calendar name                | All calendars |
-| `--calendar-id`      | —     | Filter by calendar ID                  | —             |
-| `--search`           | `-s`  | Search title, location, notes          | —             |
-| `--all-day`          | —     | Show only all-day events               | false         |
-| `--sort`             | —     | Sort by: start, end, title, calendar   | start         |
-| `--limit`            | `-n`  | Max events to display (0 = unlimited)  | 0             |
-| `--exclude-calendar` | —     | Exclude calendars by name (repeatable) | —             |
+| Flag                 | Short | Description                                | Default       |
+| -------------------- | ----- | ------------------------------------------ | ------------- |
+| `--calendar`         | `-c`  | Filter by calendar name                    | All calendars |
+| `--calendar-id`      | —     | Filter by calendar ID                      | —             |
+| `--search`           | `-s`  | Search title, location, notes              | —             |
+| `--all-day`          | —     | Show only all-day events                   | false         |
+| `--sort`             | —     | Sort by: start, end, title, calendar       | start         |
+| `--limit`            | `-n`  | Max events to display (0 = unlimited)      | 0             |
+| `--exclude-calendar` | —     | Exclude calendars by name (repeatable)     | —             |
+| `--attendee`         | `-a`  | Filter by attendee or organizer name/email | —             |
+| `--no-recurring`     | —     | Hide recurring events                      | false         |
 
 ---
 
@@ -128,16 +132,18 @@ ical upcoming --calendar Work -o json
 ical next --days 3
 ```
 
-| Flag                 | Short | Description                            | Default       |
-| -------------------- | ----- | -------------------------------------- | ------------- |
-| `--days`             | `-d`  | Number of days to look ahead           | 7             |
-| `--calendar`         | `-c`  | Filter by calendar name                | All calendars |
-| `--calendar-id`      | —     | Filter by calendar ID                  | —             |
-| `--search`           | `-s`  | Search title, location, notes          | —             |
-| `--all-day`          | —     | Show only all-day events               | false         |
-| `--sort`             | —     | Sort by: start, end, title, calendar   | start         |
-| `--limit`            | `-n`  | Max events to display (0 = unlimited)  | 0             |
-| `--exclude-calendar` | —     | Exclude calendars by name (repeatable) | —             |
+| Flag                 | Short | Description                                | Default       |
+| -------------------- | ----- | ------------------------------------------ | ------------- |
+| `--days`             | `-d`  | Number of days to look ahead               | 7             |
+| `--calendar`         | `-c`  | Filter by calendar name                    | All calendars |
+| `--calendar-id`      | —     | Filter by calendar ID                      | —             |
+| `--search`           | `-s`  | Search title, location, notes              | —             |
+| `--all-day`          | —     | Show only all-day events                   | false         |
+| `--sort`             | —     | Sort by: start, end, title, calendar       | start         |
+| `--limit`            | `-n`  | Max events to display (0 = unlimited)      | 0             |
+| `--exclude-calendar` | —     | Exclude calendars by name (repeatable)     | —             |
+| `--attendee`         | `-a`  | Filter by attendee or organizer name/email | —             |
+| `--no-recurring`     | —     | Hide recurring events                      | false         |
 
 Aliases: `next`, `soon`
 
@@ -296,12 +302,14 @@ ical search "dentist" --from "jan 1" --to "dec 31" --limit 5
 ical find "lunch" -o json
 ```
 
-| Flag         | Short | Description                 | Default       |
-| ------------ | ----- | --------------------------- | ------------- |
-| `--from`     | `-f`  | Start of search range       | 30 days ago   |
-| `--to`       | `-t`  | End of search range         | 30 days ahead |
-| `--calendar` | `-c`  | Filter by calendar name     | All calendars |
-| `--limit`    | `-n`  | Max results (0 = unlimited) | 0             |
+| Flag             | Short | Description                                | Default       |
+| ---------------- | ----- | ------------------------------------------ | ------------- |
+| `--from`         | `-f`  | Start of search range                      | 30 days ago   |
+| `--to`           | `-t`  | End of search range                        | 30 days ahead |
+| `--calendar`     | `-c`  | Filter by calendar name                    | All calendars |
+| `--attendee`     | `-a`  | Filter by attendee or organizer name/email | —             |
+| `--no-recurring` | —     | Hide recurring events                      | false         |
+| `--limit`        | `-n`  | Max results (0 = unlimited)                | 0             |
 
 Aliases: `find`
 

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -144,14 +144,16 @@ ical list -f today -t "in 7 days" -c Work
 
 ### Flags
 
-| Flag                  | Short | Description                        |
-|-----------------------|-------|------------------------------------|
-| `--from`              | `-f`  | Start date (natural language)      |
-| `--to`                | `-t`  | End date (natural language)        |
-| `--calendar`          | `-c`  | Filter by calendar name            |
-| `--exclude-calendar`  |       | Exclude calendar (repeatable)      |
-| `--limit`             | `-n`  | Maximum number of results          |
-| `--sort`              |       | Sort by: `title`, `time`, `calendar` |
+| Flag                  | Short | Description                                    |
+|-----------------------|-------|------------------------------------------------|
+| `--from`              | `-f`  | Start date (natural language)                  |
+| `--to`                | `-t`  | End date (natural language)                    |
+| `--calendar`          | `-c`  | Filter by calendar name                        |
+| `--exclude-calendar`  |       | Exclude calendar (repeatable)                  |
+| `--attendee`          | `-a`  | Filter by attendee or organizer name/email     |
+| `--no-recurring`      |       | Hide recurring events                          |
+| `--limit`             | `-n`  | Maximum number of results                      |
+| `--sort`              |       | Sort by: `title`, `time`, `calendar`           |
 
 Events are displayed with row numbers (`#1`, `#2`, ...) that can be used with `show`, `update`, and `delete`. The row mapping is cached to `~/.ical-last-list` so subsequent commands can reference events by number.
 
@@ -175,10 +177,12 @@ ical today -o json
 
 ### Flags
 
-| Flag                  | Short | Description                   |
-|-----------------------|-------|-------------------------------|
-| `--calendar`          | `-c`  | Filter by calendar name       |
-| `--exclude-calendar`  |       | Exclude calendar (repeatable) |
+| Flag                  | Short | Description                                |
+|-----------------------|-------|--------------------------------------------|
+| `--calendar`          | `-c`  | Filter by calendar name                    |
+| `--exclude-calendar`  |       | Exclude calendar (repeatable)              |
+| `--attendee`          | `-a`  | Filter by attendee or organizer name/email |
+| `--no-recurring`      |       | Hide recurring events                      |
 
 ---
 
@@ -194,13 +198,15 @@ ical upcoming -d 14 -c Work --exclude-calendar Birthdays
 
 ### Flags
 
-| Flag                  | Short | Default | Description                        |
-|-----------------------|-------|---------|------------------------------------|
-| `--days`              | `-d`  | `7`     | Number of days to look ahead       |
-| `--calendar`          | `-c`  |         | Filter by calendar name            |
-| `--exclude-calendar`  |       |         | Exclude calendar (repeatable)      |
-| `--limit`             | `-n`  |         | Maximum number of results          |
-| `--sort`              |       |         | Sort by: `title`, `time`, `calendar` |
+| Flag                  | Short | Default | Description                                    |
+|-----------------------|-------|---------|------------------------------------------------|
+| `--days`              | `-d`  | `7`     | Number of days to look ahead                   |
+| `--calendar`          | `-c`  |         | Filter by calendar name                        |
+| `--exclude-calendar`  |       |         | Exclude calendar (repeatable)                  |
+| `--attendee`          | `-a`  |         | Filter by attendee or organizer name/email     |
+| `--no-recurring`      |       |         | Hide recurring events                          |
+| `--limit`             | `-n`  |         | Maximum number of results                      |
+| `--sort`              |       |         | Sort by: `title`, `time`, `calendar`           |
 
 ---
 
@@ -407,14 +413,14 @@ ical search "meeting" -c Work -f "1 month ago" -t "in 1 month"
 
 ### Flags
 
-| Flag                  | Short | Description                        |
-|-----------------------|-------|------------------------------------|
-| `--from`              | `-f`  | Start date (natural language)      |
-| `--to`                | `-t`  | End date (natural language)        |
-| `--calendar`          | `-c`  | Filter by calendar name            |
-| `--exclude-calendar`  |       | Exclude calendar (repeatable)      |
-| `--limit`             | `-n`  | Maximum number of results          |
-| `--sort`              |       | Sort by: `title`, `time`, `calendar` |
+| Flag             | Short | Description                                |
+|------------------|-------|--------------------------------------------|
+| `--from`         | `-f`  | Start date (natural language)              |
+| `--to`           | `-t`  | End date (natural language)                |
+| `--calendar`     | `-c`  | Filter by calendar name                    |
+| `--attendee`     | `-a`  | Filter by attendee or organizer name/email |
+| `--no-recurring` |       | Hide recurring events                      |
+| `--limit`        | `-n`  | Maximum number of results                  |
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the two filter flags shipped this cycle: `--attendee` and `--no-recurring`. Touched four files:

- `website/content/docs/commands.md` — flag tables for list, today, upcoming, search
- `skills/ical-cli/references/commands.md` — same for agent-facing reference
- `skills/ical-cli/SKILL.md` — new "Filtering the agenda" workflow section with examples
- `README.md` — two examples under Event Listing

### Also in this PR: fix a pre-existing bug in `search`'s flag table

The website docs for `ical search` listed `--exclude-calendar` and `--sort` as valid flags. They are not wired up on `search` (running `ical search foo --exclude-calendar X` errors with "unknown flag"). Removed those two rows while I was editing the table anyway.

## Test plan

- [x] Verified `ical list/today/upcoming/search --help` output matches what the docs now claim
- [x] Confirmed `search` does not accept `--exclude-calendar` or `--sort`
- [x] Visual scan of table alignment in all four updated tables
