### PR TITLE
Note date column and filter-helper pattern in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ ical/
 
 ## Conventions
 - Row numbers (`#1`, `#2`...) in event tables; cached to `~/.ical-last-list` for `show 2`/`update 3`/`delete 1`
+- Event tables show a leading `Date` column with vertical merge — the date prints only on day transitions. Label built from already-localized time so grouping follows the viewer's local day
+- List-command filters live as pure helpers in `cmd/ical/commands/list.go` (`filterExcludedCalendars`, `filterRecurring`, `attendeeMatches`, `normalizeCalendarName`). Add new filters there and unit-test them in `list_test.go` — keep them slice-in / slice-out so they compose
 - Event IDs: entire UUID prefix before `:` is shared per calendar — short IDs don't disambiguate. Use row numbers or interactive picker instead
 - show/update/delete accept 0 args (interactive huh picker), row number, or full/partial event ID
 - `--to` dates: `endOfDayIfMidnight()` bumps midnight to 23:59:59 (in list, search, export, pickEvent)


### PR DESCRIPTION
Two small notes in CLAUDE.md so future sessions don't miss them when touching list output or adding filters:

- Date column in event tables — flags the vertical-merge behaviour and the local-timezone grouping so nobody re-derives this when editing `printEventsTable`
- Filter-helper pattern in `list.go` — tells future sessions where to add new list-command filters (and to keep them slice-in/slice-out so they compose cleanly)

No code changes.
