### PR TITLE
Automating code quality and security: Add golangci-lint with CI workflow and local feedback hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; [ -n \"$f\" ] && [ \"${f##*.}\" = \"go\" ] && \"$HOME/go/bin/goimports\" -w \"$f\"; } 2>/dev/null || true",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "out=$(go vet ./... 2>&1) && exit 0; jq -n --arg r \"$out\" '{decision:\"block\",reason:(\"go vet failed:\\n\"+$r)}'",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: golangci-lint
+    # macos required: go-eventkit uses cgo + Objective-C to link Apple frameworks (EventKit, Foundation, AppKit, CoreLocation)
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
 linters:
   default: standard
   enable:
+    - gosec
     - misspell
     - unconvert
     - unparam
@@ -20,6 +21,7 @@ linters:
       - path: _test\.go
         linters:
           - errcheck
+          - gosec
           - unparam
 
 formatters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+  enable:
+    - misspell
+    - unconvert
+    - unparam
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - unparam
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 
-.PHONY: all build install test clean completions release help
+.PHONY: all build install test lint clean completions release help
 
 all: build
 
@@ -17,6 +17,9 @@ install: build ## Install the binary to $GOPATH/bin
 
 test: ## Run tests
 	go test ./... -v
+
+lint: ## Run golangci-lint
+	golangci-lint run ./...
 
 release: ## Build release tarballs for GitHub upload (arm64 + amd64)
 	@mkdir -p bin

--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -346,7 +346,7 @@ func runAddInteractive() error {
 
 	// Parse alerts
 	if strings.TrimSpace(alertStr) != "" {
-		for _, a := range strings.Split(alertStr, ",") {
+		for a := range strings.SplitSeq(alertStr, ",") {
 			a = strings.TrimSpace(a)
 			if a == "" {
 				continue
@@ -391,10 +391,7 @@ func runAddInteractive() error {
 }
 
 func buildRecurrenceRule() (eventkit.RecurrenceRule, error) {
-	interval := addRepeatInterval
-	if interval < 1 {
-		interval = 1
-	}
+	interval := max(addRepeatInterval, 1)
 
 	freq := strings.ToLower(addRepeat)
 	if addRepeatDays != "" && freq != "weekly" {

--- a/cmd/ical/commands/calendars.go
+++ b/cmd/ical/commands/calendars.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/BRO3886/ical/internal/ui"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/ical/internal/ui"
 	"github.com/charmbracelet/huh"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"

--- a/cmd/ical/commands/delete.go
+++ b/cmd/ical/commands/delete.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/charmbracelet/huh"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"

--- a/cmd/ical/commands/export.go
+++ b/cmd/ical/commands/export.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/BRO3886/ical/internal/export"
-	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/go-eventkit/dateparser"
+	"github.com/BRO3886/ical/internal/export"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ical/commands/import.go
+++ b/cmd/ical/commands/import.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/BRO3886/ical/internal/export"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/ical/internal/export"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )

--- a/cmd/ical/commands/recurrence_test.go
+++ b/cmd/ical/commands/recurrence_test.go
@@ -10,15 +10,15 @@ import (
 // and that Validate() catches invalid configurations.
 func TestBuildRecurrenceRule(t *testing.T) {
 	tests := []struct {
-		name           string
-		repeat         string
-		interval       int
-		days           string
-		repeatUntil    string
-		repeatCount    int
-		wantErr        bool
-		wantFrequency  eventkit.RecurrenceFrequency
-		wantInterval   int
+		name          string
+		repeat        string
+		interval      int
+		days          string
+		repeatUntil   string
+		repeatCount   int
+		wantErr       bool
+		wantFrequency eventkit.RecurrenceFrequency
+		wantInterval  int
 	}{
 		{
 			name:          "daily",
@@ -50,33 +50,33 @@ func TestBuildRecurrenceRule(t *testing.T) {
 			wantInterval:  1,
 		},
 		{
-			name:        "with count",
-			repeat:      "daily",
-			interval:    1,
-			repeatCount: 10,
+			name:          "with count",
+			repeat:        "daily",
+			interval:      1,
+			repeatCount:   10,
 			wantFrequency: eventkit.FrequencyDaily,
 			wantInterval:  1,
 		},
 		{
-			name:        "with until",
-			repeat:      "weekly",
-			interval:    1,
-			repeatUntil: "2026-12-31",
+			name:          "with until",
+			repeat:        "weekly",
+			interval:      1,
+			repeatUntil:   "2026-12-31",
 			wantFrequency: eventkit.FrequencyWeekly,
 			wantInterval:  1,
 		},
 		{
-			name:    "invalid repeat type",
-			repeat:  "biweekly",
+			name:     "invalid repeat type",
+			repeat:   "biweekly",
 			interval: 1,
-			wantErr: true,
+			wantErr:  true,
 		},
 		{
-			name:    "invalid repeat days",
-			repeat:  "weekly",
+			name:     "invalid repeat days",
+			repeat:   "weekly",
 			interval: 1,
-			days:    "foo,bar",
-			wantErr: true,
+			days:     "foo,bar",
+			wantErr:  true,
 		},
 		{
 			name:        "invalid repeat until",
@@ -107,9 +107,9 @@ func TestBuildRecurrenceRule(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:     "zero interval defaults to 1",
-			repeat:   "daily",
-			interval: 0,
+			name:          "zero interval defaults to 1",
+			repeat:        "daily",
+			interval:      0,
 			wantFrequency: eventkit.FrequencyDaily,
 			wantInterval:  1,
 		},

--- a/cmd/ical/commands/show.go
+++ b/cmd/ical/commands/show.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BRO3886/ical/internal/ui"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/ical/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ical/commands/update.go
+++ b/cmd/ical/commands/update.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BRO3886/go-eventkit/dateparser"
-	"github.com/BRO3886/ical/internal/ui"
 	"github.com/BRO3886/go-eventkit"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/go-eventkit/dateparser"
+	"github.com/BRO3886/ical/internal/ui"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
@@ -393,7 +393,7 @@ func runUpdateInteractive(client *calendar.Client, event *calendar.Event) error 
 			input.Alerts = &empty
 		} else {
 			alerts := make([]calendar.Alert, 0)
-			for _, a := range strings.Split(alertStr, ",") {
+			for a := range strings.SplitSeq(alertStr, ",") {
 				a = strings.TrimSpace(a)
 				if a == "" {
 					continue

--- a/internal/export/ics.go
+++ b/internal/export/ics.go
@@ -146,11 +146,11 @@ func ParseICS(r io.Reader) ([]calendar.CreateEventInput, error) {
 	inAlarm := false
 
 	for _, line := range lines {
-		switch {
-		case line == "BEGIN:VEVENT":
+		switch line {
+		case "BEGIN:VEVENT":
 			cur = &icsEvent{}
 			inAlarm = false
-		case line == "END:VEVENT":
+		case "END:VEVENT":
 			if cur == nil {
 				continue
 			}
@@ -160,9 +160,9 @@ func ParseICS(r io.Reader) ([]calendar.CreateEventInput, error) {
 			}
 			inputs = append(inputs, input)
 			cur = nil
-		case line == "BEGIN:VALARM":
+		case "BEGIN:VALARM":
 			inAlarm = true
-		case line == "END:VALARM":
+		case "END:VALARM":
 			inAlarm = false
 		default:
 			if cur == nil {
@@ -208,16 +208,16 @@ func ParseICS(r io.Reader) ([]calendar.CreateEventInput, error) {
 
 // icsEvent holds parsed VEVENT properties before conversion.
 type icsEvent struct {
-	title        string
-	dtstart      string
-	dtend        string
+	title         string
+	dtstart       string
+	dtend         string
 	dtstartAllDay bool
-	dtendAllDay  bool
-	location     string
-	notes        string
-	url          string
-	rrules       []eventkit.RecurrenceRule
-	alerts       []time.Duration
+	dtendAllDay   bool
+	location      string
+	notes         string
+	url           string
+	rrules        []eventkit.RecurrenceRule
+	alerts        []time.Duration
 }
 
 func (e *icsEvent) toInput() (calendar.CreateEventInput, error) {
@@ -284,11 +284,11 @@ func unfoldICS(r io.Reader) []string {
 // splitICSLine splits "KEY:VALUE" or "KEY;PARAMS:VALUE" returning the full key
 // (including params) and the value. Returns false if the line has no colon.
 func splitICSLine(line string) (string, string, bool) {
-	idx := strings.Index(line, ":")
-	if idx < 0 {
+	before, after, ok := strings.Cut(line, ":")
+	if !ok {
 		return "", "", false
 	}
-	return line[:idx], line[idx+1:], true
+	return before, after, true
 }
 
 func unescapeICS(s string) string {
@@ -318,7 +318,7 @@ func parseRRule(val string) (eventkit.RecurrenceRule, error) {
 	rule := eventkit.RecurrenceRule{Interval: 1}
 	hasFreq := false
 
-	for _, part := range strings.Split(val, ";") {
+	for part := range strings.SplitSeq(val, ";") {
 		kv := strings.SplitN(part, "=", 2)
 		if len(kv) != 2 {
 			continue
@@ -347,7 +347,7 @@ func parseRRule(val string) (eventkit.RecurrenceRule, error) {
 			}
 			rule.Interval = n
 		case "BYDAY":
-			for _, dayStr := range strings.Split(value, ",") {
+			for dayStr := range strings.SplitSeq(value, ",") {
 				dow, err := parseBYDAY(dayStr)
 				if err != nil {
 					return rule, err
@@ -355,7 +355,7 @@ func parseRRule(val string) (eventkit.RecurrenceRule, error) {
 				rule.DaysOfTheWeek = append(rule.DaysOfTheWeek, dow)
 			}
 		case "BYMONTHDAY":
-			for _, ds := range strings.Split(value, ",") {
+			for ds := range strings.SplitSeq(value, ",") {
 				n, err := strconv.Atoi(ds)
 				if err != nil {
 					return rule, fmt.Errorf("invalid BYMONTHDAY %q: %w", ds, err)
@@ -484,8 +484,8 @@ func parseTrigger(val string) (time.Duration, error) {
 	}
 
 	// Parse seconds
-	if idx := strings.Index(s, "S"); idx >= 0 {
-		n, err := strconv.Atoi(s[:idx])
+	if before, _, ok := strings.Cut(s, "S"); ok {
+		n, err := strconv.Atoi(before)
 		if err != nil {
 			return 0, fmt.Errorf("invalid trigger seconds %q: %w", val, err)
 		}

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -10,19 +10,19 @@ import (
 )
 
 type eventExport struct {
-	ID          string    `json:"id"`
-	Title       string    `json:"title"`
-	StartDate   time.Time `json:"start_date"`
-	EndDate     time.Time `json:"end_date"`
-	AllDay      bool      `json:"all_day"`
-	Calendar    string    `json:"calendar"`
-	CalendarID  string    `json:"calendar_id"`
-	Location    string    `json:"location,omitempty"`
-	Notes       string    `json:"notes,omitempty"`
-	URL         string    `json:"url,omitempty"`
-	Status      string    `json:"status"`
-	Recurring   bool      `json:"recurring"`
-	TimeZone    string    `json:"timezone,omitempty"`
+	ID         string    `json:"id"`
+	Title      string    `json:"title"`
+	StartDate  time.Time `json:"start_date"`
+	EndDate    time.Time `json:"end_date"`
+	AllDay     bool      `json:"all_day"`
+	Calendar   string    `json:"calendar"`
+	CalendarID string    `json:"calendar_id"`
+	Location   string    `json:"location,omitempty"`
+	Notes      string    `json:"notes,omitempty"`
+	URL        string    `json:"url,omitempty"`
+	Status     string    `json:"status"`
+	Recurring  bool      `json:"recurring"`
+	TimeZone   string    `json:"timezone,omitempty"`
 }
 
 // JSON exports events as a JSON array.

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -88,7 +88,7 @@ func Install(embeddedFS fs.FS, target AgentTarget, version string) ([]string, er
 			return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
 		}
 
-		if err := os.WriteFile(destPath, data, 0o644); err != nil {
+		if err := os.WriteFile(destPath, data, 0o600); err != nil {
 			return fmt.Errorf("failed to write %s: %w", destPath, err)
 		}
 
@@ -101,7 +101,7 @@ func Install(embeddedFS fs.FS, target AgentTarget, version string) ([]string, er
 
 	// Write version tracking file
 	versionPath := filepath.Join(destDir, VersionFileName)
-	if err := os.WriteFile(versionPath, []byte(version+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(versionPath, []byte(version+"\n"), 0o600); err != nil {
 		return nil, fmt.Errorf("failed to write version file: %w", err)
 	}
 

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/BRO3886/go-eventkit"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -29,7 +29,7 @@ func SaveLastList(events []calendar.Event) {
 	for i, e := range events {
 		ids[i] = e.ID
 	}
-	_ = os.WriteFile(lastListPath(), []byte(strings.Join(ids, "\n")+"\n"), 0644)
+	_ = os.WriteFile(lastListPath(), []byte(strings.Join(ids, "\n")+"\n"), 0o600)
 }
 
 // LookupRowNumber returns the full event ID for a 1-based row number
@@ -124,36 +124,36 @@ func printEventsTable(events []calendar.Event, w io.Writer) {
 			title = title + " " + color.HiCyanString("↻")
 		}
 
-		t.Append(fmt.Sprintf("%d", i+1), dateStr, timeStr, title, calName, loc, dur)
+		_ = t.Append(fmt.Sprintf("%d", i+1), dateStr, timeStr, title, calName, loc, dur)
 	}
 
-	t.Render()
+	_ = t.Render()
 }
 
 // Events — JSON
 
 type eventJSON struct {
-	ID                 string                        `json:"id"`
-	Title              string                        `json:"title"`
-	StartDate          time.Time                     `json:"start_date"`
-	EndDate            time.Time                     `json:"end_date"`
-	AllDay             bool                          `json:"all_day"`
-	Calendar           string                        `json:"calendar"`
-	CalendarID         string                        `json:"calendar_id"`
-	Location           string                        `json:"location,omitempty"`
-	StructuredLocation *eventkit.StructuredLocation   `json:"structured_location,omitempty"`
-	Notes              string                        `json:"notes,omitempty"`
-	URL                string                        `json:"url,omitempty"`
-	Status             string                        `json:"status"`
-	Availability       string                        `json:"availability"`
-	Organizer          string                        `json:"organizer,omitempty"`
-	Attendees          []calendar.Attendee           `json:"attendees,omitempty"`
-	Recurring          bool                          `json:"recurring"`
-	RecurrenceRules    []eventkit.RecurrenceRule     `json:"recurrence_rules,omitempty"`
-	Alerts             []calendar.Alert              `json:"alerts,omitempty"`
-	TimeZone           string                        `json:"timezone,omitempty"`
-	CreatedAt          time.Time                     `json:"created_at"`
-	ModifiedAt         time.Time                     `json:"modified_at"`
+	ID                 string                       `json:"id"`
+	Title              string                       `json:"title"`
+	StartDate          time.Time                    `json:"start_date"`
+	EndDate            time.Time                    `json:"end_date"`
+	AllDay             bool                         `json:"all_day"`
+	Calendar           string                       `json:"calendar"`
+	CalendarID         string                       `json:"calendar_id"`
+	Location           string                       `json:"location,omitempty"`
+	StructuredLocation *eventkit.StructuredLocation `json:"structured_location,omitempty"`
+	Notes              string                       `json:"notes,omitempty"`
+	URL                string                       `json:"url,omitempty"`
+	Status             string                       `json:"status"`
+	Availability       string                       `json:"availability"`
+	Organizer          string                       `json:"organizer,omitempty"`
+	Attendees          []calendar.Attendee          `json:"attendees,omitempty"`
+	Recurring          bool                         `json:"recurring"`
+	RecurrenceRules    []eventkit.RecurrenceRule    `json:"recurrence_rules,omitempty"`
+	Alerts             []calendar.Alert             `json:"alerts,omitempty"`
+	TimeZone           string                       `json:"timezone,omitempty"`
+	CreatedAt          time.Time                    `json:"created_at"`
+	ModifiedAt         time.Time                    `json:"modified_at"`
 }
 
 func toEventJSON(e calendar.Event) eventJSON {
@@ -241,10 +241,10 @@ func printCalendarsTable(calendars []calendar.Calendar, w io.Writer) {
 		if c.ReadOnly {
 			readOnly = "yes"
 		}
-		t.Append(c.Title, c.Source, c.Type.String(), c.Color, readOnly)
+		_ = t.Append(c.Title, c.Source, c.Type.String(), c.Color, readOnly)
 	}
 
-	t.Render()
+	_ = t.Render()
 }
 
 // Calendars — JSON

--- a/internal/ui/output_test.go
+++ b/internal/ui/output_test.go
@@ -138,10 +138,10 @@ func TestLocalizeTimeInZone(t *testing.T) {
 	// UTC 18:00 on 2026-02-11 (chosen so wall-clock math is clean across all zones).
 	utcTime := time.Date(2026, 2, 11, 18, 0, 0, 0, time.UTC)
 
-	ist := mustLoadLocation("Asia/Kolkata")   // UTC+5:30
+	ist := mustLoadLocation("Asia/Kolkata")     // UTC+5:30
 	est := mustLoadLocation("America/New_York") // UTC-5 in February
 	cst := mustLoadLocation("America/Chicago")  // UTC-6 in February
-	gmt := mustLoadLocation("GMT")             // UTC+0
+	gmt := mustLoadLocation("GMT")              // UTC+0
 
 	t.Run("returns nil for empty tz", func(t *testing.T) {
 		// Reference location doesn't matter when tz is empty.
@@ -246,9 +246,9 @@ func TestEventDateLabel(t *testing.T) {
 	// whatever location the input carries — the caller localizes upstream.
 	utcTime := time.Date(2026, 4, 19, 15, 0, 0, 0, time.UTC)
 
-	bst := mustLoadLocation("Europe/London") // BST in April = UTC+1
+	bst := mustLoadLocation("Europe/London")    // BST in April = UTC+1
 	est := mustLoadLocation("America/New_York") // EDT in April = UTC-4
-	ist := mustLoadLocation("Asia/Kolkata")   // IST = UTC+5:30
+	ist := mustLoadLocation("Asia/Kolkata")     // IST = UTC+5:30
 
 	tests := []struct {
 		name string

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -54,7 +54,7 @@ func ReadCache(homeDir string) *CacheEntry {
 // Returns nil if the content is malformed.
 func ParseCache(content string) *CacheEntry {
 	entry := &CacheEntry{}
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -92,7 +92,7 @@ func WriteCache(homeDir string, entry *CacheEntry) error {
 		entry.CheckedAt.UTC().Format(time.RFC3339),
 		entry.Latest,
 	)
-	if err := os.WriteFile(CachePath(homeDir), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(CachePath(homeDir), []byte(content), 0o600); err != nil {
 		return nil // silently fail
 	}
 	return nil
@@ -148,7 +148,7 @@ func CompareVersions(current, latest string) bool {
 	if cur == nil || lat == nil {
 		return false
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if lat[i] > cur[i] {
 			return true
 		}
@@ -208,7 +208,7 @@ func Check(homeDir, currentVersion string) *Result {
 	}
 
 	// Write to cache (best-effort)
-	WriteCache(homeDir, &CacheEntry{
+	_ = WriteCache(homeDir, &CacheEntry{
 		CheckedAt: now,
 		Latest:    latest,
 	})

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -199,11 +199,11 @@ func TestCompareVersions(t *testing.T) {
 		{"v1.0.0", "v2.0.0", true},
 		{"v0.9.0", "v0.10.0", true},
 		{"v0.10.0", "v0.9.0", false},
-		{"0.4.0", "0.5.0", true},     // no v prefix
-		{"v0.4.0", "0.5.0", true},    // mixed prefix
-		{"dev", "v0.5.0", false},      // invalid current
-		{"v0.4.0", "invalid", false},  // invalid latest
-		{"", "v0.5.0", false},         // empty current
+		{"0.4.0", "0.5.0", true},       // no v prefix
+		{"v0.4.0", "0.5.0", true},      // mixed prefix
+		{"dev", "v0.5.0", false},       // invalid current
+		{"v0.4.0", "invalid", false},   // invalid latest
+		{"", "v0.5.0", false},          // empty current
 		{"v1.2.3-rc1", "v1.2.4", true}, // pre-release suffix
 	}
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+go = "1.24.5"
+golangci-lint = "2.11.4"
+hugo = "0.139.0"


### PR DESCRIPTION
## Why

Right now there's no code-quality gate. Regressions that a standard linter would catch (unchecked errors, weak file permissions, bad printf args, misformatted imports, tagged-switch opportunities) can ship unnoticed — CI runs no lint job, and there's no shared local config either.

This PR sets that up at three layers so issues surface as early as possible:

1. **Local dev** — `.golangci.yml` + `make lint` gives every contributor the same rules. `mise.toml` pins the exact Go and golangci-lint versions, so bootstrapping a matching environment is a single `mise install`.
2. **CI** — every push to `main` and every PR runs `golangci-lint` on `macos-latest` (required because `go-eventkit` links against EventKit/Foundation/AppKit/CoreLocation via cgo). Merging red becomes visible.
3. **Agent feedback loop** — for Claude Code sessions, `goimports -w` runs on every Go file edit and `go vet ./...` runs at the end of every turn. Formatting and type errors are fixed seconds after they're introduced, not minutes after push.

`gosec` is included in the same pipeline, so new file-permission and crypto foot-guns get flagged alongside style issues — one tool, one run.

Net effect: review time goes to logic, not mechanics.

## What's included

- `mise.toml` — toolchain pin (Go 1.24.5, golangci-lint 2.11.4, Hugo 0.139.0)
- `.golangci.yml` — v2 config: standard linters + `misspell`, `unconvert`, `unparam`, `gosec`; `gofmt` and `goimports` as formatters; relaxed rules for `*_test.go`
- `Makefile` — new `lint` target
- `.github/workflows/lint.yml` — CI lint job, `macos-latest`, reads Go version from `go.mod`
- `.claude/settings.json` — PostToolUse `goimports` and Stop `go vet` hooks for Claude Code users
- Source cleanups to make the new linter green: `errcheck` fixes (explicit `_ =` on tablewriter Append/Render and best-effort WriteCache), `gosec` G306 tightenings (0644 → 0600 for user-home cache and skill-install files), `staticcheck` QF1002 (tagged switch in the ICS parser), and `gofmt`/`goimports` normalization. A handful of `go fix` modernizations (`strings.SplitSeq`, `strings.Cut`, `for i := range 3`, `max()`) landed in the same touched files.

## Test plan

- [ ] `make lint` exits 0 locally on this branch
- [ ] GitHub Actions lint workflow passes on this PR
- [ ] `go build ./...` and `go test ./...` still pass
- [ ] Smoke-test `ical today`, `ical list`, `ical import <file.ics>` — exercises the ICS parser's refactored switch and the `strings.SplitSeq`/`Cut` call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)