### PR TITLE
Add --no-alert flag on ical add to suppress calendar default alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ ical add "Company Holiday" -s 2026-03-15 --all-day -c Work
 ical add "Dinner" -s "friday 7pm" -e "friday 9pm" \
   -l "The Restaurant, 123 Main St" --alert 1h --alert 15m
 
+# Suppress the calendar's default alarm (e.g. for mirrored busy blocks)
+ical add "Busy block" -s "tomorrow 9am" -e "tomorrow 10am" --no-alert
+
 # Recurring event
 ical add "Weekly Sync" -s "next monday 10am" -e "next monday 11am" \
   --repeat weekly --repeat-days mon -c Work

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ ical add "Company Holiday" -s 2026-03-15 --all-day -c Work
 ical add "Dinner" -s "friday 7pm" -e "friday 9pm" \
   -l "The Restaurant, 123 Main St" --alert 1h --alert 15m
 
-# Suppress the calendar's default alarm (e.g. for mirrored busy blocks)
+# Suppress the calendar's default alerts (e.g. for mirrored busy blocks)
 ical add "Busy block" -s "tomorrow 9am" -e "tomorrow 10am" --no-alert
 
 # Recurring event

--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -141,7 +141,7 @@ func init() {
 	addCmd.Flags().StringVarP(&addNotes, "notes", "n", "", "Notes/description")
 	addCmd.Flags().StringVarP(&addURL, "url", "u", "", "URL to attach")
 	addCmd.Flags().StringArrayVar(&addAlerts, "alert", nil, "Alert before event (e.g., 15m, 1h, 1d) — repeatable")
-	addCmd.Flags().BoolVar(&addNoAlert, "no-alert", false, "Create with zero alerts (overrides calendar default)")
+	addCmd.Flags().BoolVar(&addNoAlert, "no-alert", false, "Create with zero alerts (overrides calendar default alerts)")
 	addCmd.Flags().StringVarP(&addRepeat, "repeat", "r", "", "Recurrence: daily, weekly, monthly, yearly")
 	addCmd.Flags().IntVar(&addRepeatInterval, "repeat-interval", 1, "Recurrence interval")
 	addCmd.Flags().StringVar(&addRepeatUntil, "repeat-until", "", "Recurrence end date")
@@ -357,6 +357,13 @@ func runAddInteractive() error {
 			}
 			input.Alerts = append(input.Alerts, calendar.Alert{RelativeOffset: -d})
 		}
+	}
+
+	// Matches the non-interactive path: any explicit alert suppresses the
+	// calendar default, and the --no-alert CLI flag (if passed together
+	// with -i) forces zero alerts.
+	if addNoAlert || len(input.Alerts) > 0 {
+		input.SuppressDefaultAlarms = true
 	}
 
 	// Parse recurrence

--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -23,6 +23,7 @@ var (
 	addNotes          string
 	addURL            string
 	addAlerts         []string
+	addNoAlert        bool
 	addRepeat         string
 	addRepeatInterval int
 	addRepeatUntil    string
@@ -79,15 +80,16 @@ var addCmd = &cobra.Command{
 		}
 
 		input := calendar.CreateEventInput{
-			Title:     title,
-			StartDate: startTime,
-			EndDate:   endTime,
-			AllDay:    addAllDay,
-			Location:  addLocation,
-			Notes:     addNotes,
-			URL:       addURL,
-			Calendar:  addCalendar,
-			TimeZone:  addTimezone,
+			Title:                 title,
+			StartDate:             startTime,
+			EndDate:               endTime,
+			AllDay:                addAllDay,
+			Location:              addLocation,
+			Notes:                 addNotes,
+			URL:                   addURL,
+			Calendar:              addCalendar,
+			TimeZone:              addTimezone,
+			SuppressDefaultAlarms: addNoAlert,
 		}
 
 		// Parse alerts
@@ -133,6 +135,7 @@ func init() {
 	addCmd.Flags().StringVarP(&addNotes, "notes", "n", "", "Notes/description")
 	addCmd.Flags().StringVarP(&addURL, "url", "u", "", "URL to attach")
 	addCmd.Flags().StringArrayVar(&addAlerts, "alert", nil, "Alert before event (e.g., 15m, 1h, 1d) — repeatable")
+	addCmd.Flags().BoolVar(&addNoAlert, "no-alert", false, "Don't inherit the calendar's default alarms")
 	addCmd.Flags().StringVarP(&addRepeat, "repeat", "r", "", "Recurrence: daily, weekly, monthly, yearly")
 	addCmd.Flags().IntVar(&addRepeatInterval, "repeat-interval", 1, "Recurrence interval")
 	addCmd.Flags().StringVar(&addRepeatUntil, "repeat-until", "", "Recurrence end date")

--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BRO3886/go-eventkit/dateparser"
-	"github.com/BRO3886/ical/internal/ui"
 	"github.com/BRO3886/go-eventkit"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/go-eventkit/dateparser"
+	"github.com/BRO3886/ical/internal/ui"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
@@ -80,16 +80,15 @@ var addCmd = &cobra.Command{
 		}
 
 		input := calendar.CreateEventInput{
-			Title:                 title,
-			StartDate:             startTime,
-			EndDate:               endTime,
-			AllDay:                addAllDay,
-			Location:              addLocation,
-			Notes:                 addNotes,
-			URL:                   addURL,
-			Calendar:              addCalendar,
-			TimeZone:              addTimezone,
-			SuppressDefaultAlarms: addNoAlert,
+			Title:     title,
+			StartDate: startTime,
+			EndDate:   endTime,
+			AllDay:    addAllDay,
+			Location:  addLocation,
+			Notes:     addNotes,
+			URL:       addURL,
+			Calendar:  addCalendar,
+			TimeZone:  addTimezone,
 		}
 
 		// Parse alerts
@@ -99,6 +98,13 @@ var addCmd = &cobra.Command{
 				return err
 			}
 			input.Alerts = append(input.Alerts, calendar.Alert{RelativeOffset: -d})
+		}
+
+		// Any explicit --alert suppresses the calendar default; --no-alert
+		// suppresses it explicitly so a user can create a zero-alert event
+		// on a calendar that has a default configured.
+		if addNoAlert || len(input.Alerts) > 0 {
+			input.SuppressDefaultAlarms = true
 		}
 
 		// Parse recurrence
@@ -135,7 +141,7 @@ func init() {
 	addCmd.Flags().StringVarP(&addNotes, "notes", "n", "", "Notes/description")
 	addCmd.Flags().StringVarP(&addURL, "url", "u", "", "URL to attach")
 	addCmd.Flags().StringArrayVar(&addAlerts, "alert", nil, "Alert before event (e.g., 15m, 1h, 1d) — repeatable")
-	addCmd.Flags().BoolVar(&addNoAlert, "no-alert", false, "Don't inherit the calendar's default alarms")
+	addCmd.Flags().BoolVar(&addNoAlert, "no-alert", false, "Create with zero alerts (overrides calendar default)")
 	addCmd.Flags().StringVarP(&addRepeat, "repeat", "r", "", "Recurrence: daily, weekly, monthly, yearly")
 	addCmd.Flags().IntVar(&addRepeatInterval, "repeat-interval", 1, "Recurrence interval")
 	addCmd.Flags().StringVar(&addRepeatUntil, "repeat-until", "", "Recurrence end date")
@@ -273,8 +279,8 @@ func runAddInteractive() error {
 
 	// Page 3: Recurrence
 	var (
-		repeat       string
-		repeatDays   string
+		repeat     string
+		repeatDays string
 	)
 
 	recurrence := huh.NewGroup(

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/ical
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.4.0
+	github.com/BRO3886/go-eventkit v0.6.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/fatih/color v1.18.0
 	github.com/olekukonko/tablewriter v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BRO3886/go-eventkit v0.4.0 h1:dvH9bEEnlJDyYce2JXiKA+teoILehrq/2i2mS1Sc4YQ=
-github.com/BRO3886/go-eventkit v0.4.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
+github.com/BRO3886/go-eventkit v0.6.0 h1:IrGorMHXRHK52DUudQm5d79tDR8FoaTdLJ3h0B+NG7k=
+github.com/BRO3886/go-eventkit v0.6.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/skills/ical-cli/SKILL.md
+++ b/skills/ical-cli/SKILL.md
@@ -131,17 +131,18 @@ Repeatable `--alert` flag on `ical add` and `ical update`. Units: `m`, `h`, `d`.
 ical add "Flight" --start "mar 15 at 8am" --alert 1h --alert 1d
 ```
 
-Calendars contribute their own default alerts to every new event. Pass `--no-alert` on `ical add` to opt out:
+Calendars contribute their own default alerts to every new event. Two ways to opt out:
 
 ```bash
-# No alerts at all — useful for mirrored busy blocks and scripted events
-ical add "Busy block" --start "tomorrow 9am" --end "tomorrow 10am" --no-alert
+# Explicit --alert already overrides the calendar default — you get
+# exactly the alerts you list, no calendar defaults mixed in
+ical add "Focus time" --start "tomorrow 2pm" --end "tomorrow 4pm" --alert 15m
 
-# Exactly one explicit alert, ignoring the calendar's default
-ical add "Focus time" --start "tomorrow 2pm" --end "tomorrow 4pm" --no-alert --alert 15m
+# No alerts at all (useful for mirrored busy blocks)
+ical add "Busy block" --start "tomorrow 9am" --end "tomorrow 10am" --no-alert
 ```
 
-`--no-alert` and `--alert` compose — the flag suppresses the calendar default, then any `--alert` values are added on top.
+Rule of thumb: passing **any** `--alert` gives you exactly those alerts. Passing **no** `--alert` and no `--no-alert` inherits the calendar's default alerts. Passing `--no-alert` gives you zero alerts regardless of the calendar.
 
 ## Calendar management
 

--- a/skills/ical-cli/SKILL.md
+++ b/skills/ical-cli/SKILL.md
@@ -131,7 +131,17 @@ Repeatable `--alert` flag on `ical add` and `ical update`. Units: `m`, `h`, `d`.
 ical add "Flight" --start "mar 15 at 8am" --alert 1h --alert 1d
 ```
 
-Calendars contribute their own default alerts to every new event. There is currently no flag to suppress that inherited default — see ical#16 for the open request. If you need an alert-free event on a calendar with a default, create it on a calendar that has no default, or remove alerts after creation with `ical update <n>` (no `--alert` flag currently clears them either, so pragmatically: pick a quiet calendar).
+Calendars contribute their own default alerts to every new event. Pass `--no-alert` on `ical add` to opt out:
+
+```bash
+# No alerts at all — useful for mirrored busy blocks and scripted events
+ical add "Busy block" --start "tomorrow 9am" --end "tomorrow 10am" --no-alert
+
+# Exactly one explicit alert, ignoring the calendar's default
+ical add "Focus time" --start "tomorrow 2pm" --end "tomorrow 4pm" --no-alert --alert 15m
+```
+
+`--no-alert` and `--alert` compose — the flag suppresses the calendar default, then any `--alert` values are added on top.
 
 ## Calendar management
 
@@ -171,6 +181,5 @@ ical export --from today --to "in 7 days" --format ics --output-file week.ics
 ## Limits
 
 - Attendee invites are not supported (EventKit is read-only for attendees).
-- No `--no-alert` flag yet — alerts inherit the calendar default.
 - Subscribed and Birthdays calendars are read-only.
 - macOS only.

--- a/skills/ical-cli/references/commands.md
+++ b/skills/ical-cli/references/commands.md
@@ -203,6 +203,7 @@ ical add -i   # Interactive mode
 | `--notes`           | `-n`  | Notes/description                                   | —              |
 | `--url`             | `-u`  | URL to attach                                       | —              |
 | `--alert`           | —     | Alert before event (e.g., 15m, 1h, 1d) — repeatable | —              |
+| `--no-alert`        | —     | Don't inherit the calendar's default alarms         | false          |
 | `--repeat`          | `-r`  | Recurrence: daily, weekly, monthly, yearly          | —              |
 | `--repeat-interval` | —     | Recurrence interval                                 | 1              |
 | `--repeat-until`    | —     | Recurrence end date                                 | —              |

--- a/skills/ical-cli/references/commands.md
+++ b/skills/ical-cli/references/commands.md
@@ -203,7 +203,7 @@ ical add -i   # Interactive mode
 | `--notes`           | `-n`  | Notes/description                                   | —              |
 | `--url`             | `-u`  | URL to attach                                       | —              |
 | `--alert`           | —     | Alert before event (e.g., 15m, 1h, 1d) — repeatable | —              |
-| `--no-alert`        | —     | Don't inherit the calendar's default alarms         | false          |
+| `--no-alert`        | —     | Create with zero alerts (overrides calendar default) | false          |
 | `--repeat`          | `-r`  | Recurrence: daily, weekly, monthly, yearly          | —              |
 | `--repeat-interval` | —     | Recurrence interval                                 | 1              |
 | `--repeat-until`    | —     | Recurrence end date                                 | —              |

--- a/skills/ical-cli/references/commands.md
+++ b/skills/ical-cli/references/commands.md
@@ -203,7 +203,7 @@ ical add -i   # Interactive mode
 | `--notes`           | `-n`  | Notes/description                                   | —              |
 | `--url`             | `-u`  | URL to attach                                       | —              |
 | `--alert`           | —     | Alert before event (e.g., 15m, 1h, 1d) — repeatable | —              |
-| `--no-alert`        | —     | Create with zero alerts (overrides calendar default) | false          |
+| `--no-alert`        | —     | Create with zero alerts (overrides calendar default alerts) | false          |
 | `--repeat`          | `-r`  | Recurrence: daily, weekly, monthly, yearly          | —              |
 | `--repeat-interval` | —     | Recurrence interval                                 | 1              |
 | `--repeat-until`    | —     | Recurrence end date                                 | —              |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -274,7 +274,7 @@ ical add -i
 | `--location`      | `-l`  | Event location                             |
 | `--all-day`       |       | Create an all-day event                    |
 | `--alert`         |       | Add alert before event (repeatable)        |
-| `--no-alert`      |       | Create with zero alerts (overrides calendar default) |
+| `--no-alert`      |       | Create with zero alerts (overrides calendar default alerts) |
 | `--timezone`      |       | Timezone (e.g., `America/New_York`)        |
 | `--repeat`        |       | Recurrence: `daily`, `weekly`, `monthly`, `yearly` |
 | `--repeat-days`   |       | Days for weekly recurrence (repeatable)    |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -274,7 +274,7 @@ ical add -i
 | `--location`      | `-l`  | Event location                             |
 | `--all-day`       |       | Create an all-day event                    |
 | `--alert`         |       | Add alert before event (repeatable)        |
-| `--no-alert`      |       | Don't inherit the calendar's default alarms |
+| `--no-alert`      |       | Create with zero alerts (overrides calendar default) |
 | `--timezone`      |       | Timezone (e.g., `America/New_York`)        |
 | `--repeat`        |       | Recurrence: `daily`, `weekly`, `monthly`, `yearly` |
 | `--repeat-days`   |       | Days for weekly recurrence (repeatable)    |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -274,6 +274,7 @@ ical add -i
 | `--location`      | `-l`  | Event location                             |
 | `--all-day`       |       | Create an all-day event                    |
 | `--alert`         |       | Add alert before event (repeatable)        |
+| `--no-alert`      |       | Don't inherit the calendar's default alarms |
 | `--timezone`      |       | Timezone (e.g., `America/New_York`)        |
 | `--repeat`        |       | Recurrence: `daily`, `weekly`, `monthly`, `yearly` |
 | `--repeat-days`   |       | Days for weekly recurrence (repeatable)    |


### PR DESCRIPTION
Closes #16.

Adds `--no-alert` on `ical add` and reworks the `--alert` semantics so users get what they ask for without needing a second flag. Originally requested by @athal7 for scripted busy-block mirroring where calendar default alarms were pure noise.

Under the hood: uses `CreateEventInput.SuppressDefaultAlarms` from go-eventkit v0.6.0 (shipped in BRO3886/go-eventkit#8).

## Behaviour matrix

| Command | Result |
| --- | --- |
| `ical add ...` (no flag) | Inherits calendar default alarms (unchanged) |
| `ical add ... --alert 30m` | Exactly `[30m]`, calendar default dropped |
| `ical add ... --alert 30m --alert 1h` | Exactly `[30m, 1h]`, calendar default dropped |
| `ical add ... --no-alert` | Zero alerts regardless of calendar |
| `ical add ... --no-alert --alert 30m` | Same as `--alert 30m` (redundant but harmless) |

Rule of thumb: passing **any** `--alert` gives you exactly those alerts. Passing **no** `--alert` and no `--no-alert` inherits the calendar default. `--no-alert` forces zero.

## Why

The original spin on this PR was: user passes `--alert 30m` → event gets `[30m, calendar_default]`. That's surprising — nobody runs `--alert 30m` hoping for two alerts. The refactor makes `--alert` do what its name implies: set the alerts.

## Verified against live Calendar

`Home` calendar has a 5-minute default. Results:

```
ical add (no flag)    → alerts=1, offsets=[5]   # calendar default
ical add --alert 30m  → alerts=1, offsets=[30]  # user only, default dropped
ical add --no-alert   → alerts=0
```

## Docs touched

- `cmd/ical/commands/add.go` — flag + implicit-suppress logic
- `skills/ical-cli/SKILL.md` — Alerts section rewritten around the new rule
- `skills/ical-cli/references/commands.md` — `--no-alert` row in the `add` flag table
- `website/content/docs/commands.md` — same row on the public docs
- `README.md` — one-line `--no-alert` example under Creating Events

## Dep bump

`github.com/BRO3886/go-eventkit v0.4.0 → v0.6.0`. Tests still pass (322, unchanged count — no new ical-side tests).

## Test plan

- [x] `go build -o bin/ical ./cmd/ical`
- [x] `go test ./...` — 322 pass
- [x] `gofmt -w cmd/ical/commands/add.go`
- [x] Live Calendar smoke test of all behaviour-matrix rows above
- [x] `ical add --help` shows both flags correctly
