### PR TITLE
Document --alert default-alert replacement in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ ical/
 - Row numbers (`#1`, `#2`...) in event tables; cached to `~/.ical-last-list` for `show 2`/`update 3`/`delete 1`
 - Event tables show a leading `Date` column with vertical merge — the date prints only on day transitions. Label built from already-localized time so grouping follows the viewer's local day
 - List-command filters live as pure helpers in `cmd/ical/commands/list.go` (`filterExcludedCalendars`, `filterRecurring`, `attendeeMatches`, `normalizeCalendarName`). Add new filters there and unit-test them in `list_test.go` — keep them slice-in / slice-out so they compose
+- `ical add --alert X` implicitly sets `CreateEventInput.SuppressDefaultAlarms` so the saved event has exactly the user's alerts, not the calendar's default merged in. `--no-alert` alone forces zero alerts. Applies in both CLI and interactive (`-i`) paths
 - Event IDs: entire UUID prefix before `:` is shared per calendar — short IDs don't disambiguate. Use row numbers or interactive picker instead
 - show/update/delete accept 0 args (interactive huh picker), row number, or full/partial event ID
 - `--to` dates: `endOfDayIfMidnight()` bumps midnight to 23:59:59 (in list, search, export, pickEvent)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ ical add "Team Standup" -s "tomorrow 9am" -e "tomorrow 9:30am" -c Work
 ical add "Company Holiday" -s 2026-03-15 --all-day -c Work
 
 # With location and alerts
+# Passing any --alert gives the event exactly those alerts — the calendar's
+# default alerts are not merged in. Omit --alert to inherit the default,
+# or pass --no-alert for zero alerts.
 ical add "Dinner" -s "friday 7pm" -e "friday 9pm" \
   -l "The Restaurant, 123 Main St" --alert 1h --alert 15m
 

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -288,8 +288,13 @@ ical add -i
 ical add "Company Holiday" -s 2026-03-15 --all-day -c Work
 
 # With location and multiple alerts
+# Passing any --alert gives the event exactly those alerts — the calendar's
+# default alerts are not merged in. Omit --alert to inherit the default.
 ical add "Dinner" -s "friday 7pm" -e "friday 9pm" \
   -l "The Restaurant, 123 Main St" --alert 1h --alert 15m
+
+# Suppress the calendar's default alerts (e.g. for mirrored busy blocks)
+ical add "Busy block" -s "tomorrow 9am" -e "tomorrow 10am" --no-alert
 
 # Weekly recurring event
 ical add "Weekly Sync" -s "next monday 10am" -e "next monday 11am" \


### PR DESCRIPTION
Two small docs additions so the alert-semantics change from #31 doesn't surprise anyone.

- `CLAUDE.md` — one line noting that `--alert` implicitly sets `SuppressDefaultAlarms` on `CreateEventInput`, so future sessions touching `add.go` don't re-derive the rule wrong.
- `README.md` — inline comment next to the `--alert` example clarifying that passing `--alert` gives exactly those alerts, the calendar's default is not merged in. Matters for anyone upgrading from v0.8.0 who was implicitly relying on the additive behaviour.

No code changes.