### PR TITLE
Show full date including year when events span multiple years

### DIFF
--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -93,6 +93,8 @@ func printEventsTable(events []calendar.Event, w io.Writer) {
 		return
 	}
 
+	showYear := eventsSpanMultipleYears(events)
+
 	t := tablewriter.NewTable(w,
 		tablewriter.WithConfig(tablewriter.Config{
 			Header: tw.CellConfig{Formatting: tw.CellFormatting{Alignment: tw.AlignCenter}},
@@ -110,7 +112,7 @@ func printEventsTable(events []calendar.Event, w io.Writer) {
 	for i, e := range events {
 		start := localizeTime(e.StartDate, e.TimeZone)
 		end := localizeTime(e.EndDate, e.TimeZone)
-		dateStr := eventDateLabel(start)
+		dateStr := eventDateLabel(start, showYear)
 		timeStr := dateparser.FormatTimeRange(start, end, e.AllDay)
 		title := truncate(e.Title, 40)
 		loc := truncate(e.Location, 25)
@@ -527,12 +529,24 @@ func localizeTime(t time.Time, _ string) time.Time {
 	return t.In(time.Local)
 }
 
-// eventDateLabel returns the date-column label for an event row.
-// The input must already be localized — the label uses whatever
-// location is on t, which is what makes same-instant events group
-// under the viewer's local day rather than UTC.
-func eventDateLabel(t time.Time) string {
+func eventDateLabel(t time.Time, showYear bool) string {
+	if showYear {
+		return t.Format("Mon 02 Jan 2006")
+	}
 	return t.Format("Mon 02 Jan")
+}
+
+func eventsSpanMultipleYears(events []calendar.Event) bool {
+	if len(events) == 0 {
+		return false
+	}
+	first := events[0].StartDate.Year()
+	for _, e := range events[1:] {
+		if e.StartDate.Year() != first {
+			return true
+		}
+	}
+	return false
 }
 
 // localizeTimeInZone converts a time to the event's own timezone.

--- a/internal/ui/output_test.go
+++ b/internal/ui/output_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/BRO3886/go-eventkit"
+	"github.com/BRO3886/go-eventkit/calendar"
 )
 
 func TestShortID(t *testing.T) {
@@ -270,9 +271,44 @@ func TestEventDateLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := eventDateLabel(tt.in)
+			got := eventDateLabel(tt.in, false)
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("showYear includes the year", func(t *testing.T) {
+		got := eventDateLabel(utcTime.In(bst), true)
+		want := "Sun 19 Apr 2026"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestEventsSpanMultipleYears(t *testing.T) {
+	makeEvent := func(year int, month time.Month, day int) calendar.Event {
+		return calendar.Event{StartDate: time.Date(year, month, day, 10, 0, 0, 0, time.UTC)}
+	}
+
+	tests := []struct {
+		name   string
+		events []calendar.Event
+		want   bool
+	}{
+		{"empty", nil, false},
+		{"single event", []calendar.Event{makeEvent(2026, 5, 1)}, false},
+		{"same year", []calendar.Event{makeEvent(2026, 1, 1), makeEvent(2026, 12, 31)}, false},
+		{"different years", []calendar.Event{makeEvent(2025, 12, 31), makeEvent(2026, 1, 1)}, true},
+		{"three years", []calendar.Event{makeEvent(2024, 6, 1), makeEvent(2025, 6, 1), makeEvent(2026, 6, 1)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := eventsSpanMultipleYears(tt.events)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- When events in a table span multiple calendar years, the Date column now includes the year (e.g. `Mon 13 Jan 2025` instead of `Mon 13 Jan`)
- Single-year results stay compact with no year shown
- Year detection derived from the events themselves — no API or flag changes needed

Closes #33

## Test plan
- [x] `ical search "meeting" --from 2025-01-01 --to 2026-12-31` — year appears in Date column
- [x] `ical today` — no year in Date column (same-year events)
- [x] Unit tests for `eventDateLabel` with showYear=true/false
- [x] Unit tests for `eventsSpanMultipleYears` (empty, single, same-year, multi-year)
- [x] Full test suite passes (329 tests)
