### PR TITLE
Support multiple -c options for calendar filtering

### DIFF
--- a/cmd/ical/commands/export.go
+++ b/cmd/ical/commands/export.go
@@ -50,7 +50,9 @@ var exportCmd = &cobra.Command{
 
 		var opts []calendar.ListOption
 		if len(exportCalendars) == 1 {
-			opts = append(opts, calendar.WithCalendar(exportCalendars[0]))
+			if n := normalizeCalendarName(exportCalendars[0]); n != "" {
+				opts = append(opts, calendar.WithCalendar(n))
+			}
 		}
 
 		events, err := client.Events(from, to, opts...)

--- a/cmd/ical/commands/export.go
+++ b/cmd/ical/commands/export.go
@@ -14,7 +14,7 @@ import (
 var (
 	exportFrom       string
 	exportTo         string
-	exportCalendar   string
+	exportCalendars  []string
 	exportFormatFlag string
 	exportOutputFile string
 )
@@ -49,14 +49,16 @@ var exportCmd = &cobra.Command{
 		}
 
 		var opts []calendar.ListOption
-		if exportCalendar != "" {
-			opts = append(opts, calendar.WithCalendar(exportCalendar))
+		if len(exportCalendars) == 1 {
+			opts = append(opts, calendar.WithCalendar(exportCalendars[0]))
 		}
 
 		events, err := client.Events(from, to, opts...)
 		if err != nil {
 			return fmt.Errorf("failed to fetch events: %w", err)
 		}
+
+		events = filterIncludedCalendars(events, exportCalendars)
 
 		w := os.Stdout
 		if exportOutputFile != "" {
@@ -82,7 +84,7 @@ var exportCmd = &cobra.Command{
 func init() {
 	exportCmd.Flags().StringVarP(&exportFrom, "from", "f", "", "Start date (default: 30 days ago)")
 	exportCmd.Flags().StringVarP(&exportTo, "to", "t", "", "End date (default: 30 days ahead)")
-	exportCmd.Flags().StringVarP(&exportCalendar, "calendar", "c", "", "Filter by calendar")
+	exportCmd.Flags().StringArrayVarP(&exportCalendars, "calendar", "c", nil, "Filter by calendar name (repeatable)")
 	exportCmd.Flags().StringVar(&exportFormatFlag, "format", "json", "Format: json, csv, ics")
 	exportCmd.Flags().StringVar(&exportOutputFile, "output-file", "", "Write to file instead of stdout")
 

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -15,7 +15,7 @@ import (
 var (
 	listFrom            string
 	listTo              string
-	listCalendar        string
+	listCalendars       []string
 	listCalendarID      string
 	listSearch          string
 	listAllDay          bool
@@ -59,7 +59,7 @@ var listCmd = &cobra.Command{
 func init() {
 	listCmd.Flags().StringVarP(&listFrom, "from", "f", "", "Start date (natural language or ISO 8601)")
 	listCmd.Flags().StringVarP(&listTo, "to", "t", "", "End date (natural language or ISO 8601)")
-	listCmd.Flags().StringVarP(&listCalendar, "calendar", "c", "", "Filter by calendar name")
+	listCmd.Flags().StringArrayVarP(&listCalendars, "calendar", "c", nil, "Filter by calendar name (repeatable)")
 	listCmd.Flags().StringVar(&listCalendarID, "calendar-id", "", "Filter by calendar ID")
 	listCmd.Flags().StringVarP(&listSearch, "search", "s", "", "Search title, location, notes")
 	listCmd.Flags().BoolVar(&listAllDay, "all-day", false, "Show only all-day events")
@@ -95,6 +95,7 @@ func listEvents(from, to time.Time) error {
 	}
 
 	events = filterExcludedCalendars(events, listExcludeCalendar)
+	events = filterIncludedCalendars(events, listCalendars)
 
 	if listNoRecurring {
 		events = filterRecurring(events)
@@ -122,8 +123,8 @@ func listEvents(from, to time.Time) error {
 
 func buildListOptions() []calendar.ListOption {
 	var opts []calendar.ListOption
-	if listCalendar != "" {
-		opts = append(opts, calendar.WithCalendar(listCalendar))
+	if len(listCalendars) == 1 {
+		opts = append(opts, calendar.WithCalendar(listCalendars[0]))
 	}
 	if listCalendarID != "" {
 		opts = append(opts, calendar.WithCalendarID(listCalendarID))
@@ -209,6 +210,34 @@ func filterExcludedCalendars(events []calendar.Event, exclude []string) []calend
 	filtered := make([]calendar.Event, 0, len(events))
 	for _, e := range events {
 		if !excluded[normalizeCalendarName(e.Calendar)] {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+// filterIncludedCalendars keeps only events whose calendar name matches any of
+// the user-supplied names after normalization. An empty include list is a no-op
+// (all events pass through). Include entries that normalize to the empty string
+// are ignored so a whitespace-only flag value cannot accidentally filter everything out.
+func filterIncludedCalendars(events []calendar.Event, include []string) []calendar.Event {
+	if len(include) == 0 {
+		return events
+	}
+	included := make(map[string]bool, len(include))
+	for _, c := range include {
+		normalized := normalizeCalendarName(c)
+		if normalized == "" {
+			continue
+		}
+		included[normalized] = true
+	}
+	if len(included) == 0 {
+		return events
+	}
+	filtered := make([]calendar.Event, 0, len(events))
+	for _, e := range events {
+		if included[normalizeCalendarName(e.Calendar)] {
 			filtered = append(filtered, e)
 		}
 	}

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -95,7 +95,9 @@ func listEvents(from, to time.Time) error {
 	}
 
 	events = filterExcludedCalendars(events, listExcludeCalendar)
-	events = filterIncludedCalendars(events, listCalendars)
+	if len(listCalendars) > 1 {
+		events = filterIncludedCalendars(events, listCalendars)
+	}
 
 	if listNoRecurring {
 		events = filterRecurring(events)
@@ -216,10 +218,6 @@ func filterExcludedCalendars(events []calendar.Event, exclude []string) []calend
 	return filtered
 }
 
-// filterIncludedCalendars keeps only events whose calendar name matches any of
-// the user-supplied names after normalization. An empty include list is a no-op
-// (all events pass through). Include entries that normalize to the empty string
-// are ignored so a whitespace-only flag value cannot accidentally filter everything out.
 func filterIncludedCalendars(events []calendar.Event, include []string) []calendar.Event {
 	if len(include) == 0 {
 		return events

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -126,7 +126,9 @@ func listEvents(from, to time.Time) error {
 func buildListOptions() []calendar.ListOption {
 	var opts []calendar.ListOption
 	if len(listCalendars) == 1 {
-		opts = append(opts, calendar.WithCalendar(listCalendars[0]))
+		if n := normalizeCalendarName(listCalendars[0]); n != "" {
+			opts = append(opts, calendar.WithCalendar(n))
+		}
 	}
 	if listCalendarID != "" {
 		opts = append(opts, calendar.WithCalendarID(listCalendarID))

--- a/cmd/ical/commands/list_test.go
+++ b/cmd/ical/commands/list_test.go
@@ -81,6 +81,60 @@ func TestFilterRecurring(t *testing.T) {
 	})
 }
 
+func TestFilterIncludedCalendars(t *testing.T) {
+	events := []calendar.Event{
+		{Title: "A", Calendar: "Work"},
+		{Title: "B", Calendar: "Personal"},
+		{Title: "C", Calendar: ""},
+		{Title: "D", Calendar: "  Holidays  "},
+	}
+
+	titles := func(evs []calendar.Event) []string {
+		out := make([]string, len(evs))
+		for i, e := range evs {
+			out[i] = e.Title
+		}
+		return out
+	}
+
+	eq := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	tests := []struct {
+		name    string
+		include []string
+		want    []string
+	}{
+		{"nil include keeps everything", nil, []string{"A", "B", "C", "D"}},
+		{"empty slice keeps everything", []string{}, []string{"A", "B", "C", "D"}},
+		{"single exact match", []string{"Work"}, []string{"A"}},
+		{"case insensitive match", []string{"personal"}, []string{"B"}},
+		{"padded flag matches padded calendar name", []string{"Holidays"}, []string{"D"}},
+		{"multiple includes", []string{"Work", "Personal"}, []string{"A", "B"}},
+		{"unknown include yields empty result", []string{"Nonexistent"}, []string{}},
+		{"whitespace-only include is a no-op (keeps everything)", []string{"   "}, []string{"A", "B", "C", "D"}},
+		{"whitespace-only mixed with valid include applies only the valid one", []string{"   ", "Work"}, []string{"A"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := titles(filterIncludedCalendars(events, tt.include))
+			if !eq(got, tt.want) {
+				t.Errorf("titles = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFilterExcludedCalendars(t *testing.T) {
 	events := []calendar.Event{
 		{Title: "A", Calendar: "Work"},

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -14,7 +14,7 @@ import (
 var (
 	searchFrom        string
 	searchTo          string
-	searchCalendar    string
+	searchCalendars   []string
 	searchLimit       int
 	searchAttendee    string
 	searchNoRecurring bool
@@ -54,14 +54,16 @@ var searchCmd = &cobra.Command{
 		}
 
 		opts := []calendar.ListOption{calendar.WithSearch(query)}
-		if searchCalendar != "" {
-			opts = append(opts, calendar.WithCalendar(searchCalendar))
+		if len(searchCalendars) == 1 {
+			opts = append(opts, calendar.WithCalendar(searchCalendars[0]))
 		}
 
 		events, err := client.Events(from, to, opts...)
 		if err != nil {
 			return fmt.Errorf("failed to search events: %w", err)
 		}
+
+		events = filterIncludedCalendars(events, searchCalendars)
 
 		if searchAttendee != "" {
 			filtered := make([]calendar.Event, 0, len(events))
@@ -89,7 +91,7 @@ var searchCmd = &cobra.Command{
 func init() {
 	searchCmd.Flags().StringVarP(&searchFrom, "from", "f", "", "Start of search range (default: 30 days ago)")
 	searchCmd.Flags().StringVarP(&searchTo, "to", "t", "", "End of search range (default: 30 days ahead)")
-	searchCmd.Flags().StringVarP(&searchCalendar, "calendar", "c", "", "Filter by calendar")
+	searchCmd.Flags().StringArrayVarP(&searchCalendars, "calendar", "c", nil, "Filter by calendar name (repeatable)")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 0, "Max results")
 	searchCmd.Flags().StringVarP(&searchAttendee, "attendee", "a", "", "Filter by attendee or organizer name/email")
 	searchCmd.Flags().BoolVar(&searchNoRecurring, "no-recurring", false, "Hide recurring events")

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -55,7 +55,9 @@ var searchCmd = &cobra.Command{
 
 		opts := []calendar.ListOption{calendar.WithSearch(query)}
 		if len(searchCalendars) == 1 {
-			opts = append(opts, calendar.WithCalendar(searchCalendars[0]))
+			if n := normalizeCalendarName(searchCalendars[0]); n != "" {
+				opts = append(opts, calendar.WithCalendar(n))
+			}
 		}
 
 		events, err := client.Events(from, to, opts...)

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -63,7 +63,9 @@ var searchCmd = &cobra.Command{
 			return fmt.Errorf("failed to search events: %w", err)
 		}
 
-		events = filterIncludedCalendars(events, searchCalendars)
+		if len(searchCalendars) > 1 {
+			events = filterIncludedCalendars(events, searchCalendars)
+		}
 
 		if searchAttendee != "" {
 			filtered := make([]calendar.Event, 0, len(events))

--- a/cmd/ical/commands/today.go
+++ b/cmd/ical/commands/today.go
@@ -19,7 +19,7 @@ var todayCmd = &cobra.Command{
 }
 
 func init() {
-	todayCmd.Flags().StringVarP(&listCalendar, "calendar", "c", "", "Filter by calendar name")
+	todayCmd.Flags().StringArrayVarP(&listCalendars, "calendar", "c", nil, "Filter by calendar name (repeatable)")
 	todayCmd.Flags().StringVar(&listCalendarID, "calendar-id", "", "Filter by calendar ID")
 	todayCmd.Flags().StringVarP(&listSearch, "search", "s", "", "Search title, location, notes")
 	todayCmd.Flags().BoolVar(&listAllDay, "all-day", false, "Show only all-day events")

--- a/cmd/ical/commands/upcoming.go
+++ b/cmd/ical/commands/upcoming.go
@@ -23,7 +23,7 @@ var upcomingCmd = &cobra.Command{
 
 func init() {
 	upcomingCmd.Flags().IntVarP(&upcomingDays, "days", "d", 7, "Number of days to look ahead")
-	upcomingCmd.Flags().StringVarP(&listCalendar, "calendar", "c", "", "Filter by calendar name")
+	upcomingCmd.Flags().StringArrayVarP(&listCalendars, "calendar", "c", nil, "Filter by calendar name (repeatable)")
 	upcomingCmd.Flags().StringVar(&listCalendarID, "calendar-id", "", "Filter by calendar ID")
 	upcomingCmd.Flags().StringVarP(&listSearch, "search", "s", "", "Search title, location, notes")
 	upcomingCmd.Flags().BoolVar(&listAllDay, "all-day", false, "Show only all-day events")


### PR DESCRIPTION
Adds support for passing `-c` / `--calendar` multiple times to filter events across several calendars at once.

## What changed

- `listCalendar string` → `listCalendars []string` in `list`, `today`, and `upcoming` commands
- `searchCalendar string` → `searchCalendars []string` in `search`
- All four commands now use `StringArrayVarP` instead of `StringVarP` for `-c`
- New `filterIncludedCalendars(events, include []string)` helper in `list.go`, mirroring the existing `filterExcludedCalendars` pattern — case-insensitive, whitespace-tolerant
- When exactly one `-c` is given, `WithCalendar` is still passed to EventKit for server-side efficiency; for two or more, filtering is done client-side after fetch
- 9 unit tests added in `list_test.go` covering nil/empty passthrough, exact match, case-insensitive, padded names, multiple values, unknown names, and whitespace-only edge cases

## Usage

```sh
ical list -c Work -c Personal
ical today -c "Side Project" -c Personal
ical upcoming -c Work -c Family
ical search standup -c Work -c "Side Project"
```

Closes #35
