### PR TITLE
Fix recurring-event bugs: date-only repeat-until and whole-series delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,11 @@ ical delete 3 -f
 # Batch delete multiple events
 ical delete 1 2 3 --force
 
-# Delete future occurrences
+# Delete this and future occurrences
 ical delete 2 --span future
+
+# Delete the entire recurring series
+ical delete 2 --span all
 ```
 
 ## Export & Import

--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -109,7 +109,7 @@ var addCmd = &cobra.Command{
 
 		// Parse recurrence
 		if addRepeat != "" {
-			rule, err := buildRecurrenceRule()
+			rule, err := buildRecurrenceRule(addTimezone)
 			if err != nil {
 				return err
 			}
@@ -373,7 +373,7 @@ func runAddInteractive() error {
 		addRepeatDays = repeatDays
 		addRepeatUntil = ""
 		addRepeatCount = 0
-		rule, err := buildRecurrenceRule()
+		rule, err := buildRecurrenceRule(tz)
 		if err != nil {
 			return err
 		}
@@ -390,7 +390,12 @@ func runAddInteractive() error {
 	return nil
 }
 
-func buildRecurrenceRule() (eventkit.RecurrenceRule, error) {
+// buildRecurrenceRule builds the recurrence rule from the addRepeat* globals.
+// timezone is the event's IANA zone (may be empty) and is used only to compute
+// the end-of-day --repeat-until bound in the right zone; callers must pass it
+// explicitly since this is shared by add and update, which track the zone in
+// different globals.
+func buildRecurrenceRule(timezone string) (eventkit.RecurrenceRule, error) {
 	interval := addRepeatInterval
 	if interval < 1 {
 		interval = 1
@@ -426,10 +431,10 @@ func buildRecurrenceRule() (eventkit.RecurrenceRule, error) {
 			return rule, fmt.Errorf("invalid --repeat-until: %w", err)
 		}
 		var loc *time.Location
-		if addTimezone != "" {
-			loc, err = time.LoadLocation(addTimezone)
+		if timezone != "" {
+			loc, err = time.LoadLocation(timezone)
 			if err != nil {
-				return rule, fmt.Errorf("invalid timezone %q: %w", addTimezone, err)
+				return rule, fmt.Errorf("invalid timezone %q: %w", timezone, err)
 			}
 		}
 		rule = rule.Until(repeatUntilBound(t, loc))

--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -425,7 +425,14 @@ func buildRecurrenceRule() (eventkit.RecurrenceRule, error) {
 		if err != nil {
 			return rule, fmt.Errorf("invalid --repeat-until: %w", err)
 		}
-		rule = rule.Until(t)
+		var loc *time.Location
+		if addTimezone != "" {
+			loc, err = time.LoadLocation(addTimezone)
+			if err != nil {
+				return rule, fmt.Errorf("invalid timezone %q: %w", addTimezone, err)
+			}
+		}
+		rule = rule.Until(repeatUntilBound(t, loc))
 	}
 
 	if addRepeatCount > 0 {
@@ -437,6 +444,20 @@ func buildRecurrenceRule() (eventkit.RecurrenceRule, error) {
 	}
 
 	return rule, nil
+}
+
+// repeatUntilBound returns the inclusive UNTIL bound for a parsed --repeat-until
+// value. A date-only value parses to midnight; an RRULE UNTIL at 00:00 excludes
+// any occurrence later that same day, so the series ends a day early (issue #39).
+// Snapping a midnight bound to end-of-day keeps an occurrence that falls anywhere
+// on the named calendar day. When the event carries an explicit timezone,
+// end-of-day is computed in that zone so the absolute instant lines up with the
+// occurrence's wall-clock day.
+func repeatUntilBound(t time.Time, loc *time.Location) time.Time {
+	if loc != nil {
+		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc)
+	}
+	return endOfDayIfMidnight(t)
 }
 
 var weekdayMap = map[string]eventkit.Weekday{

--- a/cmd/ical/commands/delete.go
+++ b/cmd/ical/commands/delete.go
@@ -34,8 +34,16 @@ Use --from/--to or --days to control the picker's date range.
 
 With one argument, accepts a row number from the last listing or a full/partial event ID.
 With multiple arguments, performs a batch delete using row numbers or event IDs.
-Use --id for exact event ID lookup (no prefix matching, single event only).`,
+Use --id for exact event ID lookup (no prefix matching, single event only).
+
+For recurring events, --span controls scope: this (default, the targeted
+occurrence), future (this and later occurrences), or all (the whole series).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		span, err := spanFromFlag(deleteSpan)
+		if err != nil {
+			return err
+		}
+
 		client, err := calendar.New()
 		if err != nil {
 			return handleClientError(err)
@@ -44,11 +52,6 @@ Use --id for exact event ID lookup (no prefix matching, single event only).`,
 		idFlagSet := cmd.Flags().Changed("id")
 		if idFlagSet && len(args) > 0 {
 			return fmt.Errorf("cannot use both --id and a positional argument")
-		}
-
-		span := calendar.SpanThisEvent
-		if deleteSpan == "future" {
-			span = calendar.SpanFutureEvents
 		}
 
 		// Batch delete: multiple positional args
@@ -98,8 +101,10 @@ Use --id for exact event ID lookup (no prefix matching, single event only).`,
 		}
 
 		green := color.New(color.FgGreen, color.Bold)
-		green.Print("Deleted: ")
-		fmt.Printf("%s\n", event.Title)
+		green.Println(deletedMessage(event.Title, deleteSpan, event.Recurring))
+		if event.Recurring && span == calendar.SpanThisEvent {
+			fmt.Println("Other occurrences remain — use --span all to delete the whole series.")
+		}
 		return nil
 	},
 }
@@ -137,9 +142,11 @@ func runBatchDelete(client *calendar.Client, args []string, span calendar.Span) 
 	// Collect IDs and delete in batch
 	ids := make([]string, len(events))
 	nameByID := make(map[string]string, len(events))
+	recurringByID := make(map[string]bool, len(events))
 	for i, e := range events {
 		ids[i] = e.ID
 		nameByID[e.ID] = e.Title
+		recurringByID[e.ID] = e.Recurring
 	}
 
 	errs := client.DeleteEvents(ids, span)
@@ -153,8 +160,7 @@ func runBatchDelete(client *calendar.Client, args []string, span calendar.Span) 
 			fmt.Printf("%s — %v\n", nameByID[id], err)
 			failed++
 		} else {
-			green.Print("Deleted: ")
-			fmt.Printf("%s\n", nameByID[id])
+			green.Println(deletedMessage(nameByID[id], deleteSpan, recurringByID[id]))
 		}
 	}
 
@@ -164,9 +170,40 @@ func runBatchDelete(client *calendar.Client, args []string, span calendar.Span) 
 	return nil
 }
 
+// spanFromFlag maps the --span flag value to a calendar.Span. "all" deletes the
+// entire series: an event lookup resolves to the first occurrence, so future-span
+// from there removes this and every later occurrence (all = this + future).
+func spanFromFlag(s string) (calendar.Span, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "this":
+		return calendar.SpanThisEvent, nil
+	case "future", "all":
+		return calendar.SpanFutureEvents, nil
+	default:
+		return calendar.SpanThisEvent, fmt.Errorf("invalid --span %q (use this, future, or all)", s)
+	}
+}
+
+// deletedMessage returns the confirmation line for a deleted event. Recurring
+// events get span-aware wording so a single-occurrence delete is not mistaken
+// for removing the whole series (issue #40).
+func deletedMessage(title, span string, recurring bool) string {
+	if !recurring {
+		return fmt.Sprintf("Deleted: %s", title)
+	}
+	switch strings.ToLower(strings.TrimSpace(span)) {
+	case "future":
+		return fmt.Sprintf("Deleted recurring series %q (this and future occurrences)", title)
+	case "all":
+		return fmt.Sprintf("Deleted recurring series %q (all occurrences)", title)
+	default:
+		return fmt.Sprintf("Deleted 1 occurrence of recurring series %q", title)
+	}
+}
+
 func init() {
 	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation prompt")
-	deleteCmd.Flags().StringVar(&deleteSpan, "span", "this", "For recurring: this or future")
+	deleteCmd.Flags().StringVar(&deleteSpan, "span", "this", "For recurring events: this, future, or all")
 	deleteCmd.Flags().StringVar(&deleteFrom, "from", "", "Start date for event picker")
 	deleteCmd.Flags().StringVar(&deleteTo, "to", "", "End date for event picker")
 	deleteCmd.Flags().IntVarP(&deleteDays, "days", "d", 7, "Number of days to show in picker")

--- a/cmd/ical/commands/delete_test.go
+++ b/cmd/ical/commands/delete_test.go
@@ -103,6 +103,70 @@ func TestLocalizeEventTime(t *testing.T) {
 	})
 }
 
+// TestSpanFromFlag verifies --span flag parsing, including the new "all" value.
+func TestSpanFromFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    calendar.Span
+		wantErr bool
+	}{
+		{"empty defaults to this", "", calendar.SpanThisEvent, false},
+		{"this", "this", calendar.SpanThisEvent, false},
+		{"future", "future", calendar.SpanFutureEvents, false},
+		{"all maps to future", "all", calendar.SpanFutureEvents, false},
+		{"case-insensitive", "ALL", calendar.SpanFutureEvents, false},
+		{"trims whitespace", " future ", calendar.SpanFutureEvents, false},
+		{"unknown errors", "everything", calendar.SpanThisEvent, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := spanFromFlag(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeletedMessage verifies span-aware confirmation wording for recurring
+// events versus the plain message for single events (issue #40).
+func TestDeletedMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		title     string
+		span      string
+		recurring bool
+		want      string
+	}{
+		{"non-recurring", "Lunch", "this", false, "Deleted: Lunch"},
+		{"non-recurring with all span", "Lunch", "all", false, "Deleted: Lunch"},
+		{"recurring this", "Test club", "this", true, `Deleted 1 occurrence of recurring series "Test club"`},
+		{"recurring default span", "Test club", "", true, `Deleted 1 occurrence of recurring series "Test club"`},
+		{"recurring future", "Test club", "future", true, `Deleted recurring series "Test club" (this and future occurrences)`},
+		{"recurring all", "Test club", "all", true, `Deleted recurring series "Test club" (all occurrences)`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deletedMessage(tt.title, tt.span, tt.recurring)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestStartOfDay verifies the start-of-day helper.
 func TestStartOfDay(t *testing.T) {
 	input := time.Date(2026, 3, 15, 14, 30, 45, 123, time.Local)

--- a/cmd/ical/commands/recurrence_test.go
+++ b/cmd/ical/commands/recurrence_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"testing"
+	"time"
 
 	"github.com/BRO3886/go-eventkit"
 )
@@ -140,6 +141,57 @@ func TestBuildRecurrenceRule(t *testing.T) {
 			}
 			if rule.Interval != tt.wantInterval {
 				t.Errorf("interval: got %d, want %d", rule.Interval, tt.wantInterval)
+			}
+		})
+	}
+}
+
+// TestRepeatUntilBound verifies that a date-only --repeat-until is snapped to
+// end-of-day so an occurrence later that same day is kept (issue #39), while an
+// explicit time is preserved.
+func TestRepeatUntilBound(t *testing.T) {
+	ist, err := time.LoadLocation("Asia/Kolkata")
+	if err != nil {
+		t.Fatalf("load Asia/Kolkata: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   time.Time
+		loc  *time.Location
+		want time.Time
+	}{
+		{
+			name: "date-only midnight local bumped to end of day",
+			in:   time.Date(2026, 8, 14, 0, 0, 0, 0, time.Local),
+			loc:  nil,
+			want: time.Date(2026, 8, 14, 23, 59, 59, 0, time.Local),
+		},
+		{
+			name: "explicit time left untouched",
+			in:   time.Date(2026, 8, 14, 21, 30, 0, 0, time.Local),
+			loc:  nil,
+			want: time.Date(2026, 8, 14, 21, 30, 0, 0, time.Local),
+		},
+		{
+			name: "date-only reinterpreted in event timezone, end of day",
+			in:   time.Date(2026, 8, 14, 0, 0, 0, 0, time.Local),
+			loc:  ist,
+			want: time.Date(2026, 8, 14, 23, 59, 59, 0, ist),
+		},
+		{
+			name: "explicit time reinterpreted in event timezone, not bumped",
+			in:   time.Date(2026, 8, 14, 21, 30, 0, 0, time.Local),
+			loc:  ist,
+			want: time.Date(2026, 8, 14, 21, 30, 0, 0, ist),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := repeatUntilBound(tt.in, tt.loc)
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/ical/commands/recurrence_test.go
+++ b/cmd/ical/commands/recurrence_test.go
@@ -125,7 +125,7 @@ func TestBuildRecurrenceRule(t *testing.T) {
 			addRepeatUntil = tt.repeatUntil
 			addRepeatCount = tt.repeatCount
 
-			rule, err := buildRecurrenceRule()
+			rule, err := buildRecurrenceRule("")
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")
@@ -194,6 +194,36 @@ func TestRepeatUntilBound(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuildRecurrenceRuleUntilTimezone verifies that the timezone passed to
+// buildRecurrenceRule reaches the date-only --repeat-until bound, so the
+// end-of-day instant is computed in the event's zone. This is the path the
+// update command relies on (it tracks the zone in a different global than add).
+func TestBuildRecurrenceRuleUntilTimezone(t *testing.T) {
+	ist, err := time.LoadLocation("Asia/Kolkata")
+	if err != nil {
+		t.Fatalf("load Asia/Kolkata: %v", err)
+	}
+
+	addRepeat = "weekly"
+	addRepeatInterval = 1
+	addRepeatDays = ""
+	addRepeatUntil = "2026-08-14"
+	addRepeatCount = 0
+
+	rule, err := buildRecurrenceRule("Asia/Kolkata")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rule.End == nil || rule.End.EndDate == nil {
+		t.Fatal("expected an UNTIL bound, got none")
+	}
+
+	want := time.Date(2026, 8, 14, 23, 59, 59, 0, ist)
+	if !rule.End.EndDate.Equal(want) {
+		t.Errorf("UNTIL bound: got %v, want %v", rule.End.EndDate, want)
 	}
 }
 

--- a/cmd/ical/commands/update.go
+++ b/cmd/ical/commands/update.go
@@ -151,7 +151,11 @@ Use -i for interactive mode with guided prompts.`,
 				addRepeatUntil = updateRepeatUntil
 				addRepeatCount = updateRepeatCount
 				addRepeatDays = updateRepeatDays
-				rule, err := buildRecurrenceRule()
+				tz := event.TimeZone
+				if cmd.Flags().Changed("timezone") {
+					tz = updateTimezone
+				}
+				rule, err := buildRecurrenceRule(tz)
 				if err != nil {
 					return err
 				}

--- a/skills/ical-cli/SKILL.md
+++ b/skills/ical-cli/SKILL.md
@@ -124,6 +124,8 @@ ical add "Anniversary" --start "jun 15" --repeat yearly --repeat-until "2030-06-
 
 `ical update <n> --repeat none` removes recurrence. `ical update <n> --span future` changes this and all future occurrences; without it only the single instance is modified.
 
+To delete a whole recurring series use `ical delete <n> --span all`. The default `--span this` removes only one occurrence — the rest of the series stays.
+
 ## Alerts
 
 Repeatable `--alert` flag on `ical add` and `ical update`. Units: `m`, `h`, `d`.

--- a/skills/ical-cli/references/commands.md
+++ b/skills/ical-cli/references/commands.md
@@ -206,7 +206,7 @@ ical add -i   # Interactive mode
 | `--no-alert`        | —     | Create with zero alerts (overrides calendar default alerts) | false          |
 | `--repeat`          | `-r`  | Recurrence: daily, weekly, monthly, yearly          | —              |
 | `--repeat-interval` | —     | Recurrence interval                                 | 1              |
-| `--repeat-until`    | —     | Recurrence end date                                 | —              |
+| `--repeat-until`    | —     | Recurrence end date (a bare date includes the whole day) | —              |
 | `--repeat-count`    | —     | Number of occurrences                               | 0              |
 | `--repeat-days`     | —     | Days for weekly recurrence (e.g., mon,wed,fri)      | —              |
 | `--timezone`        | —     | IANA timezone (e.g., America/New_York)              | —              |
@@ -271,6 +271,7 @@ ical rm 2 --force                                  # Alias
 ical delete 1 2 3 --force                          # Batch delete multiple events
 ical delete                                        # Interactive picker
 ical delete 3 --span future                        # Delete this and future occurrences
+ical delete 3 --span all --force                   # Delete the entire recurring series
 ical delete --id "577B8983-DF44:ABC123" --force   # Exact event ID (agents: use this)
 ```
 
@@ -278,7 +279,7 @@ ical delete --id "577B8983-DF44:ABC123" --force   # Exact event ID (agents: use 
 | --------- | ----- | -------------------------------------------- | ------- |
 | `--id`    | —     | Full event ID (exact match, no prefix search) | —       |
 | `--force` | `-f`  | Skip confirmation prompt                     | false   |
-| `--span`  | —     | For recurring: "this" or "future"            | this    |
+| `--span`  | —     | For recurring: "this", "future", or "all" (whole series) | this    |
 | `--from`  | —     | Start date for event picker                  | Today   |
 | `--to`    | —     | End date for event picker                    | —       |
 | `--days`  | `-d`  | Number of days to show in picker             | 7       |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -281,7 +281,7 @@ ical add -i
 | `--timezone`      |       | Timezone (e.g., `America/New_York`)        |
 | `--repeat`        |       | Recurrence: `daily`, `weekly`, `monthly`, `yearly` |
 | `--repeat-days`   |       | Days for weekly recurrence (repeatable)    |
-| `--repeat-until`  |       | Recurrence end date                        |
+| `--repeat-until`  |       | Recurrence end date (a bare date includes the whole day) |
 | `--interactive`   | `-i`  | Use guided interactive form                |
 
 ### Examples
@@ -393,7 +393,7 @@ ical delete --id "577B8983-DF44:abc" --force
 |------------|-------|-----------------------------------------------|
 | `--id`     |       | Full event ID — exact match, no prefix search |
 | `--force`  | `-f`  | Skip confirmation prompt                      |
-| `--span`   |       | Apply to: `this` or `future` occurrences      |
+| `--span`   |       | For recurring: `this`, `future`, or `all` (whole series) |
 
 ### Batch Delete
 


### PR DESCRIPTION
Closes #39
Closes #40

Fixes two recurring-event bugs reported in #39 and #40, on a branch off the latest `main` (which now includes the emoji table fix from #41).

## Issue #39 — date-only `--repeat-until` drops a same-day occurrence

A bare `--repeat-until "2026-08-14"` parses to midnight, and an RRULE `UNTIL` at `00:00` excludes any occurrence later that same day. A weekly series whose start time is, say, 21:30 silently ends one event short, with no warning.

**Fix:** snap a date-only bound to end-of-day (`23:59:59`). When the event carries an explicit `--timezone`, the end-of-day is computed in that zone so the absolute instant lines up with the occurrence's wall-clock day. An explicit time on `--repeat-until` is left untouched.

## Issue #40 — deleting a whole series is unintuitive, single deletes look misleading

Two problems:
1. `delete --id <series>` defaults to `--span this`, removing one occurrence but printing a bare `Deleted: <title>` that reads as "the series is gone."
2. There was no ergonomic "delete the whole series."

**Fix:**
- Add `--span all` to delete the entire series. Because every occurrence of a series shares one `eventIdentifier` and EventKit's `eventWithIdentifier:` always resolves to the first occurrence, future-span from there removes the whole series (`all = this + future`).
- Validate the `--span` value. Previously any unknown value (a typo like `--span all` before this change, or `--span foo`) silently fell through to a single-occurrence delete. It now errors early.
- Span-aware messaging for recurring events:
  - `this`: `Deleted 1 occurrence of recurring series "X"` + a hint to use `--span all`
  - `future`: `Deleted recurring series "X" (this and future occurrences)`
  - `all`: `Deleted recurring series "X" (all occurrences)`
  - non-recurring events keep the original `Deleted: X`

## Tests

New unit tests, all passing (`go test ./...`, 370+ tests, `go vet` clean):
- `repeatUntilBound` — date-only midnight bumped to end-of-day; explicit time preserved; timezone-aware reinterpretation.
- `spanFromFlag` — this/future/all mapping, case-insensitive, whitespace-trimmed, unknown errors.
- `deletedMessage` — span-aware wording for recurring vs plain message for single events.

## Smoke testing

Verified end-to-end on the iCloud **Work** calendar (all test events created during testing were deleted afterward; the calendar was swept clean):
- **#39:** weekly series Jul 3 → `--repeat-until "2026-08-14"` produced 7 occurrences with the Aug 14 21:30 occurrence present (`2026-08-14T16:00:00Z`). Before the fix this would be 6.
- **#40:** `--span this` removed one occurrence (7 → 6) with the corrected message and hint; `--span all` cleared the whole series (→ 0); `--span future` cleared a fresh series; invalid `--span everything` errored early; non-recurring delete kept `Deleted: <title>`.
- **Discriminating check:** confirmed all four occurrences of a series share one identifier, and targeting the 3rd occurrence's id with `--span all` deleted the entire series (remaining 0, not 2) — so `--span all` is correct for any targeted occurrence, not just the first.

## Docs

Updated README, the docs website, and the embedded agent skill (`SKILL.md` + references) for `--span all` and the whole-day `--repeat-until` behavior.
