### PR TITLE
Add a join command and surface event conference links

### DIFF
--- a/cmd/ical/commands/join.go
+++ b/cmd/ical/commands/join.go
@@ -2,11 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
 	"time"
 
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/ical/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +46,13 @@ full/partial event ID, same as 'ical show'.`,
 			}
 		} else {
 			now := time.Now()
-			events, err := client.Events(now.Add(-12*time.Hour), now.AddDate(0, 0, joinDays))
+			// EventKit's range predicate uses overlap semantics, so any
+			// ongoing event is returned as long as the range starts before it
+			// ends. Start at local midnight anyway so all-day events for
+			// "today" are reliably in range across timezones.
+			y, m, d := now.Date()
+			dayStart := time.Date(y, m, d, 0, 0, 0, 0, time.Local)
+			events, err := client.Events(dayStart, now.AddDate(0, 0, joinDays))
 			if err != nil {
 				return fmt.Errorf("failed to fetch events: %w", err)
 			}
@@ -58,9 +66,14 @@ full/partial event ID, same as 'ical show'.`,
 			fmt.Println(event.ConferenceURL)
 			return nil
 		}
+		if outputFormat == "json" {
+			ui.PrintEventDetail(event, "json")
+			return nil
+		}
 
 		start := event.StartDate.In(time.Local)
-		fmt.Printf("Joining %q (%s)\n%s\n", event.Title, start.Format("Mon 15:04"), event.ConferenceURL)
+		fmt.Fprintf(os.Stderr, "Joining %q (%s)\n", event.Title, start.Format("Mon 15:04"))
+		fmt.Println(event.ConferenceURL)
 		if err := exec.Command("open", event.ConferenceURL).Run(); err != nil {
 			return fmt.Errorf("failed to open conference link: %w", err)
 		}

--- a/cmd/ical/commands/join.go
+++ b/cmd/ical/commands/join.go
@@ -1,0 +1,108 @@
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"time"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/spf13/cobra"
+)
+
+var (
+	joinPrint bool
+	joinDays  int
+)
+
+var joinCmd = &cobra.Command{
+	Use:   "join [number or id]",
+	Short: "Open the meeting link of the current or next event",
+	Long: `Opens the video-conference link (Zoom, Meet, Teams, FaceTime, ...) of an event.
+
+With no arguments, picks the event you most likely want to join: a meeting
+happening right now, or else the next upcoming event that has a conference
+link (searched over the next --days days).
+
+With an argument, accepts a row number from the last listing or a
+full/partial event ID, same as 'ical show'.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := calendar.New()
+		if err != nil {
+			return handleClientError(err)
+		}
+
+		var event *calendar.Event
+		if len(args) == 1 {
+			event, err = findEventByPrefix(client, args[0])
+			if err != nil {
+				return err
+			}
+			if event.ConferenceURL == "" {
+				return fmt.Errorf("event %q has no conference link", event.Title)
+			}
+		} else {
+			now := time.Now()
+			events, err := client.Events(now.Add(-12*time.Hour), now.AddDate(0, 0, joinDays))
+			if err != nil {
+				return fmt.Errorf("failed to fetch events: %w", err)
+			}
+			event = nextJoinableEvent(events, now)
+			if event == nil {
+				return fmt.Errorf("no event with a conference link in the next %d day(s)", joinDays)
+			}
+		}
+
+		if joinPrint {
+			fmt.Println(event.ConferenceURL)
+			return nil
+		}
+
+		start := event.StartDate.In(time.Local)
+		fmt.Printf("Joining %q (%s)\n%s\n", event.Title, start.Format("Mon 15:04"), event.ConferenceURL)
+		if err := exec.Command("open", event.ConferenceURL).Run(); err != nil {
+			return fmt.Errorf("failed to open conference link: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	joinCmd.Flags().BoolVarP(&joinPrint, "print", "p", false, "Print the conference link instead of opening it")
+	joinCmd.Flags().IntVarP(&joinDays, "days", "d", 7, "How many days ahead to look for the next meeting")
+
+	rootCmd.AddCommand(joinCmd)
+}
+
+// nextJoinableEvent picks the event whose conference link the user most
+// likely wants: an ongoing event (started, not yet ended) with a link —
+// preferring the most recently started one — or else the upcoming linked
+// event that starts soonest. Returns nil if no event has a conference link.
+func nextJoinableEvent(events []calendar.Event, now time.Time) *calendar.Event {
+	var ongoing, upcoming []calendar.Event
+	for _, e := range events {
+		if e.ConferenceURL == "" {
+			continue
+		}
+		switch {
+		case !e.StartDate.After(now) && e.EndDate.After(now):
+			ongoing = append(ongoing, e)
+		case e.StartDate.After(now):
+			upcoming = append(upcoming, e)
+		}
+	}
+	if len(ongoing) > 0 {
+		sort.SliceStable(ongoing, func(i, j int) bool {
+			return ongoing[i].StartDate.After(ongoing[j].StartDate)
+		})
+		return &ongoing[0]
+	}
+	if len(upcoming) > 0 {
+		sort.SliceStable(upcoming, func(i, j int) bool {
+			return upcoming[i].StartDate.Before(upcoming[j].StartDate)
+		})
+		return &upcoming[0]
+	}
+	return nil
+}

--- a/cmd/ical/commands/join_test.go
+++ b/cmd/ical/commands/join_test.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+)
+
+func joinEvt(title, conf string, start, end time.Time) calendar.Event {
+	return calendar.Event{Title: title, ConferenceURL: conf, StartDate: start, EndDate: end}
+}
+
+func TestNextJoinableEvent(t *testing.T) {
+	now := time.Date(2026, 6, 11, 14, 0, 0, 0, time.UTC)
+	h := func(d time.Duration) time.Time { return now.Add(d) }
+
+	tests := []struct {
+		name   string
+		events []calendar.Event
+		want   string // title of expected pick; "" means nil
+	}{
+		{"empty slice", nil, ""},
+		{
+			"no events have links",
+			[]calendar.Event{joinEvt("a", "", h(-time.Hour), h(time.Hour))},
+			"",
+		},
+		{
+			"ongoing beats upcoming",
+			[]calendar.Event{
+				joinEvt("later", "https://zoom.us/j/2", h(30*time.Minute), h(time.Hour)),
+				joinEvt("now", "https://zoom.us/j/1", h(-30*time.Minute), h(30*time.Minute)),
+			},
+			"now",
+		},
+		{
+			"most recently started ongoing wins",
+			[]calendar.Event{
+				joinEvt("long standup", "https://zoom.us/j/1", h(-2*time.Hour), h(time.Hour)),
+				joinEvt("just started", "https://zoom.us/j/2", h(-5*time.Minute), h(time.Hour)),
+			},
+			"just started",
+		},
+		{
+			"ongoing without link is skipped in favor of upcoming with link",
+			[]calendar.Event{
+				joinEvt("now no link", "", h(-time.Hour), h(time.Hour)),
+				joinEvt("next with link", "https://meet.google.com/abc-defg-hij", h(time.Hour), h(2*time.Hour)),
+			},
+			"next with link",
+		},
+		{
+			"soonest upcoming wins",
+			[]calendar.Event{
+				joinEvt("tomorrow", "https://zoom.us/j/2", h(24*time.Hour), h(25*time.Hour)),
+				joinEvt("in 10m", "https://zoom.us/j/1", h(10*time.Minute), h(time.Hour)),
+			},
+			"in 10m",
+		},
+		{
+			"ended events are ignored",
+			[]calendar.Event{
+				joinEvt("over", "https://zoom.us/j/1", h(-2*time.Hour), h(-time.Hour)),
+			},
+			"",
+		},
+		{
+			"event ending exactly now is not ongoing",
+			[]calendar.Event{
+				joinEvt("ends now", "https://zoom.us/j/1", h(-time.Hour), now),
+			},
+			"",
+		},
+		{
+			"event starting exactly now is ongoing",
+			[]calendar.Event{
+				joinEvt("starts now", "https://zoom.us/j/1", now, h(time.Hour)),
+			},
+			"starts now",
+		},
+		{
+			"stable tie on identical upcoming starts",
+			[]calendar.Event{
+				joinEvt("first listed", "https://zoom.us/j/1", h(time.Hour), h(2*time.Hour)),
+				joinEvt("second listed", "https://zoom.us/j/2", h(time.Hour), h(2*time.Hour)),
+			},
+			"first listed",
+		},
+		{
+			"all-day ongoing event with link is joinable",
+			[]calendar.Event{
+				{Title: "workshop", ConferenceURL: "https://zoom.us/j/1", StartDate: h(-6 * time.Hour), EndDate: h(18 * time.Hour), AllDay: true},
+			},
+			"workshop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nextJoinableEvent(tt.events, now)
+			switch {
+			case tt.want == "" && got != nil:
+				t.Errorf("got %q, want nil", got.Title)
+			case tt.want != "" && got == nil:
+				t.Errorf("got nil, want %q", tt.want)
+			case tt.want != "" && got.Title != tt.want:
+				t.Errorf("got %q, want %q", got.Title, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextJoinableEvent_DoesNotMutateInput(t *testing.T) {
+	now := time.Date(2026, 6, 11, 14, 0, 0, 0, time.UTC)
+	events := []calendar.Event{
+		joinEvt("b", "https://zoom.us/j/2", now.Add(2*time.Hour), now.Add(3*time.Hour)),
+		joinEvt("a", "https://zoom.us/j/1", now.Add(time.Hour), now.Add(2*time.Hour)),
+	}
+	_ = nextJoinableEvent(events, now)
+	if events[0].Title != "b" || events[1].Title != "a" {
+		t.Error("input slice order was mutated")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/ical
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.7.0
+	github.com/BRO3886/go-eventkit v0.14.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/fatih/color v1.18.0
 	github.com/mattn/go-runewidth v0.0.19

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BRO3886/go-eventkit v0.7.0 h1:CucIaC5Wpk8bcSlssK73MUUF839WvMOu7zncaKIFkHA=
-github.com/BRO3886/go-eventkit v0.7.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
+github.com/BRO3886/go-eventkit v0.14.0 h1:7ZLru98CSE2q6d899C0FrT6QFEZ6Fvcpi1jf+N1hlY0=
+github.com/BRO3886/go-eventkit v0.14.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -147,6 +147,7 @@ type eventJSON struct {
 	StructuredLocation *eventkit.StructuredLocation   `json:"structured_location,omitempty"`
 	Notes              string                        `json:"notes,omitempty"`
 	URL                string                        `json:"url,omitempty"`
+	ConferenceURL      string                        `json:"conference_url,omitempty"`
 	Status             string                        `json:"status"`
 	Availability       string                        `json:"availability"`
 	Organizer          string                        `json:"organizer,omitempty"`
@@ -172,6 +173,7 @@ func toEventJSON(e calendar.Event) eventJSON {
 		StructuredLocation: e.StructuredLocation,
 		Notes:              e.Notes,
 		URL:                e.URL,
+		ConferenceURL:      e.ConferenceURL,
 		Status:             e.Status.String(),
 		Availability:       e.Availability.String(),
 		Organizer:          e.Organizer,
@@ -323,6 +325,11 @@ func printEventDetailTable(e *calendar.Event, w io.Writer) {
 		fmt.Fprintln(w, e.URL)
 	}
 
+	if e.ConferenceURL != "" {
+		bold.Fprintf(w, "Conference:   ")
+		fmt.Fprintln(w, color.HiGreenString(e.ConferenceURL))
+	}
+
 	if e.Notes != "" {
 		bold.Fprintf(w, "Notes:        ")
 		fmt.Fprintln(w, e.Notes)
@@ -402,6 +409,9 @@ func printEventDetailPlain(e *calendar.Event, w io.Writer) {
 	}
 	if e.Location != "" {
 		fmt.Fprintf(w, "Location: %s\n", e.Location)
+	}
+	if e.ConferenceURL != "" {
+		fmt.Fprintf(w, "Conference: %s\n", e.ConferenceURL)
 	}
 	if e.Notes != "" {
 		fmt.Fprintf(w, "Notes: %s\n", e.Notes)


### PR DESCRIPTION
Phase 1 of #46: conference URL support, built on go-eventkit v0.14.0 (BRO3886/go-eventkit#20, released as v0.14.0).

## What's new

- **`ical join`** — opens the meeting link of the event you most likely want: an ongoing meeting (most recently started wins), or else the soonest upcoming event with a link, searched `--days` ahead (default 7). Accepts a row number or event ID positionally, same resolution as `show`. `--print` outputs the URL instead of opening it (script-friendly).
- **`ical show`** now displays a `Conference:` line (table and plain formats) when the event has a join link.
- **JSON output** gains `conference_url` on events.

The link itself comes from go-eventkit: the private EventKit accessor when available, with a pure-Go detector over url/location/notes as fallback (Zoom, Meet, Teams, FaceTime, Webex, Jitsi, Whereby, Chime, GoToMeeting).

Also bumps go-eventkit v0.7.0 → v0.14.0; the full ical test suite passes unchanged across that jump.

## Testing

**Unit tests** (`join_test.go`): selection semantics for `nextJoinableEvent` — ongoing beats upcoming, most-recently-started ongoing wins, linkless events skipped, ended events ignored, boundary instants (event starting exactly now is ongoing; ending exactly now is not), stable tie-break on identical starts, all-day events joinable, input slice not mutated.

**Smoke tests** (real iCloud Work calendar, dev build):
- created an event with a Zoom link in notes; `show` renders `Conference:` in table and plain output; JSON carries `conference_url`
- `join --print` with no args picked it (next upcoming with a link) and printed the URL
- `join <row> --print` resolves row numbers from the last listing
- `join <row>` on a linkless event errors cleanly ("has no conference link")
- smoke event deleted afterwards

Note: 12 files fail `gofmt -l` on main already (pre-existing import-order/alignment drift); this PR doesn't reformat them. The new files are gofmt-clean.
