### PR TITLE
Add attendee invites, RSVP, free/busy, and invitation inbox

### DIFF
--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -42,6 +42,9 @@ var addCmd = &cobra.Command{
 	Long:    "Creates a new calendar event. Title can be passed as argument or via --title flag.\nUse -i for interactive mode with guided prompts.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if addInteractive {
+			if len(addInvite) > 0 || addTravel != "" {
+				return fmt.Errorf("--invite and --travel are not supported in interactive mode (-i); pass them on the non-interactive command line")
+			}
 			return runAddInteractive()
 		}
 

--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -31,6 +31,8 @@ var (
 	addRepeatDays     string
 	addTimezone       string
 	addInteractive    bool
+	addInvite         []string
+	addTravel         string
 )
 
 var addCmd = &cobra.Command{
@@ -116,9 +118,27 @@ var addCmd = &cobra.Command{
 			input.RecurrenceRules = []eventkit.RecurrenceRule{rule}
 		}
 
+		// Parse invitees and travel time.
+		attendees, err := parseAttendees(addInvite)
+		if err != nil {
+			return err
+		}
+		input.Attendees = attendees
+		if addTravel != "" {
+			d, err := dateparser.ParseAlertDuration(addTravel)
+			if err != nil {
+				return fmt.Errorf("invalid --travel duration: %w", err)
+			}
+			input.TravelTime = d
+		}
+
 		client, err := calendar.New()
 		if err != nil {
 			return handleClientError(err)
+		}
+
+		if len(input.Attendees) > 0 && !client.AttendeeWritesSupported() {
+			return fmt.Errorf("inviting attendees is not supported on this macOS version")
 		}
 
 		event, err := client.CreateEvent(input)
@@ -127,8 +147,61 @@ var addCmd = &cobra.Command{
 		}
 
 		ui.PrintCreatedEvent(event)
+		if len(input.Attendees) > 0 {
+			fmt.Printf("Invited %d attendee(s); invitations are sent by the calendar account.\n", len(input.Attendees))
+		}
 		return nil
 	},
+}
+
+// parseAttendees converts --invite values into attendee inputs. Each value is
+// either a bare email ("a@x.com") or a named form ("Alice <a@x.com>"). It
+// returns an error for entries with no usable email address.
+func parseAttendees(invites []string) ([]calendar.AttendeeInput, error) {
+	if len(invites) == 0 {
+		return nil, nil
+	}
+	out := make([]calendar.AttendeeInput, 0, len(invites))
+	for _, raw := range invites {
+		name, email := splitNameEmail(raw)
+		if !looksLikeEmail(email) {
+			return nil, fmt.Errorf("invalid --invite value %q (expected an email or \"Name <email>\"; pass --invite once per person)", raw)
+		}
+		out = append(out, calendar.AttendeeInput{Name: name, Email: email})
+	}
+	return out, nil
+}
+
+// looksLikeEmail does a deliberately permissive check: exactly one "@" with
+// non-empty local and domain parts, a dot in the domain, and no internal
+// whitespace or commas. The comma/space guard catches the common mistake of
+// packing several addresses into one --invite value, which would otherwise be
+// saved as a single malformed attendee.
+func looksLikeEmail(s string) bool {
+	if s == "" || strings.ContainsAny(s, " \t,;") {
+		return false
+	}
+	at := strings.IndexByte(s, '@')
+	if at <= 0 || at != strings.LastIndexByte(s, '@') {
+		return false
+	}
+	domain := s[at+1:]
+	return len(domain) >= 3 && strings.Contains(domain, ".") &&
+		!strings.HasPrefix(domain, ".") && !strings.HasSuffix(domain, ".")
+}
+
+// splitNameEmail parses "Name <email>" or a bare email. The returned name is
+// empty for the bare form.
+func splitNameEmail(raw string) (name, email string) {
+	s := strings.TrimSpace(raw)
+	if i := strings.LastIndex(s, "<"); i >= 0 {
+		if j := strings.Index(s[i:], ">"); j >= 0 {
+			email = strings.TrimSpace(s[i+1 : i+j])
+			name = strings.TrimSpace(s[:i])
+			return name, email
+		}
+	}
+	return "", s
 }
 
 func init() {
@@ -148,6 +221,8 @@ func init() {
 	addCmd.Flags().IntVar(&addRepeatCount, "repeat-count", 0, "Recurrence occurrence count")
 	addCmd.Flags().StringVar(&addRepeatDays, "repeat-days", "", "Days for weekly recurrence (e.g., mon,wed,fri)")
 	addCmd.Flags().StringVar(&addTimezone, "timezone", "", "IANA timezone (e.g., America/New_York)")
+	addCmd.Flags().StringArrayVar(&addInvite, "invite", nil, "Invite an attendee by email or \"Name <email>\" — repeatable (sends an invitation)")
+	addCmd.Flags().StringVar(&addTravel, "travel", "", "Travel time before the event (e.g., 30m, 1h)")
 	addCmd.Flags().BoolVarP(&addInteractive, "interactive", "i", false, "Interactive mode with guided prompts")
 
 	rootCmd.AddCommand(addCmd)

--- a/cmd/ical/commands/free.go
+++ b/cmd/ical/commands/free.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/go-eventkit/dateparser"
+	"github.com/spf13/cobra"
+)
+
+var (
+	freeFrom string
+	freeTo   string
+)
+
+var freeCmd = &cobra.Command{
+	Use:   "free <email> [email...]",
+	Short: "Look up free/busy availability for people",
+	Long: `Shows free/busy availability for one or more email addresses over a time range.
+
+Requires a calendar account whose server supports availability lookups
+(Exchange or Google Workspace). iCloud does not support free/busy, so an
+iCloud-only setup will report that no account supports the lookup.
+
+Defaults to the next 24 hours; use --from/--to to change the window.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		start := time.Now()
+		if freeFrom != "" {
+			t, err := dateparser.ParseDate(freeFrom)
+			if err != nil {
+				return fmt.Errorf("invalid --from: %w", err)
+			}
+			start = t
+		}
+		end := start.Add(24 * time.Hour)
+		if freeTo != "" {
+			t, err := dateparser.ParseDate(freeTo)
+			if err != nil {
+				return fmt.Errorf("invalid --to: %w", err)
+			}
+			end = endOfDayIfMidnight(t)
+		}
+
+		client, err := calendar.New()
+		if err != nil {
+			return handleClientError(err)
+		}
+		if !client.AvailabilitySupported() {
+			return fmt.Errorf("availability lookup is not supported on this macOS version")
+		}
+
+		result, err := client.RequestAvailability(args, start, end)
+		if err != nil {
+			return fmt.Errorf("availability lookup failed: %w", err)
+		}
+
+		printAvailability(result, args)
+		return nil
+	},
+}
+
+func init() {
+	freeCmd.Flags().StringVarP(&freeFrom, "from", "f", "", "Start of the window (default: now)")
+	freeCmd.Flags().StringVarP(&freeTo, "to", "t", "", "End of the window (default: +24h)")
+	rootCmd.AddCommand(freeCmd)
+}
+
+// printAvailability renders the per-address spans in the order the addresses
+// were requested, so output is deterministic regardless of map iteration.
+func printAvailability(result map[string][]calendar.AvailabilitySpan, addresses []string) {
+	for _, addr := range addresses {
+		spans := result[addr]
+		busy := filterBusySpans(spans)
+		if len(busy) == 0 {
+			fmt.Printf("%s: free for the whole window\n", addr)
+			continue
+		}
+		fmt.Printf("%s:\n", addr)
+		for _, s := range busy {
+			fmt.Printf("  %s – %s  %s\n",
+				s.Start.In(time.Local).Format("Mon 02 Jan 15:04"),
+				s.End.In(time.Local).Format("15:04"),
+				s.Type)
+		}
+	}
+}
+
+// filterBusySpans drops free spans and sorts the rest by start time. Only
+// busy/tentative/unavailable periods are interesting when scheduling.
+func filterBusySpans(spans []calendar.AvailabilitySpan) []calendar.AvailabilitySpan {
+	out := make([]calendar.AvailabilitySpan, 0, len(spans))
+	for _, s := range spans {
+		if s.Type != calendar.AvailabilityTypeFree {
+			out = append(out, s)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Start.Before(out[j].Start) })
+	return out
+}

--- a/cmd/ical/commands/free.go
+++ b/cmd/ical/commands/free.go
@@ -27,6 +27,12 @@ iCloud-only setup will report that no account supports the lookup.
 Defaults to the next 24 hours; use --from/--to to change the window.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, addr := range args {
+			if !looksLikeEmail(addr) {
+				return fmt.Errorf("%q does not look like an email address", addr)
+			}
+		}
+
 		start := time.Now()
 		if freeFrom != "" {
 			t, err := dateparser.ParseDate(freeFrom)

--- a/cmd/ical/commands/inbox.go
+++ b/cmd/ical/commands/inbox.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -24,6 +25,12 @@ var inboxCmd = &cobra.Command{
 			return fmt.Errorf("failed to fetch invitations: %w", err)
 		}
 
+		if outputFormat == "json" {
+			data, _ := json.Marshal(invitations)
+			fmt.Println(string(data))
+			return nil
+		}
+
 		if len(invitations) == 0 {
 			fmt.Println("No pending invitations.")
 			return nil
@@ -43,7 +50,10 @@ var inboxCmd = &cobra.Command{
 			}
 			fmt.Println()
 		}
-		fmt.Println("\nRespond with: ical rsvp accepted|declined|tentative <id>")
+		// The invitation inbox carries no stable event ID, so there's nothing
+		// to pass to `rsvp` by reference. Point users at the interactive
+		// picker, which is the reliable way to respond.
+		fmt.Println("\nRespond with: ical rsvp accepted   (then pick the event interactively)")
 		return nil
 	},
 }

--- a/cmd/ical/commands/inbox.go
+++ b/cmd/ical/commands/inbox.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/spf13/cobra"
+)
+
+var inboxCmd = &cobra.Command{
+	Use:   "inbox",
+	Short: "List pending event invitations",
+	Long:  "Lists event invitations awaiting your response (the Calendar.app notification inbox).",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := calendar.New()
+		if err != nil {
+			return handleClientError(err)
+		}
+
+		invitations, err := client.PendingInvitations()
+		if err != nil {
+			return fmt.Errorf("failed to fetch invitations: %w", err)
+		}
+
+		if len(invitations) == 0 {
+			fmt.Println("No pending invitations.")
+			return nil
+		}
+
+		for i, inv := range invitations {
+			when := inv.Start.In(time.Local).Format("Mon 02 Jan 15:04")
+			if inv.AllDay {
+				when = inv.Start.In(time.Local).Format("Mon 02 Jan") + " (all day)"
+			}
+			fmt.Printf("%d. %s\n   %s", i+1, inv.Title, when)
+			if inv.Organizer != "" {
+				fmt.Printf(" · from %s", inv.Organizer)
+			}
+			if inv.Location != "" {
+				fmt.Printf(" · %s", inv.Location)
+			}
+			fmt.Println()
+		}
+		fmt.Println("\nRespond with: ical rsvp accepted|declined|tentative <id>")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(inboxCmd)
+}

--- a/cmd/ical/commands/rsvp.go
+++ b/cmd/ical/commands/rsvp.go
@@ -39,7 +39,9 @@ to the organizer.`,
 		if len(args) == 2 {
 			event, err = findEventByPrefix(client, args[1])
 		} else {
-			event, err = pickEvent(client, "", "", 7)
+			// Invitations are commonly weeks out, so the picker scans a much
+			// wider window than the self-event commands (show/delete) do.
+			event, err = pickEvent(client, "", "", 90)
 		}
 		if err != nil {
 			return err

--- a/cmd/ical/commands/rsvp.go
+++ b/cmd/ical/commands/rsvp.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/spf13/cobra"
+)
+
+var rsvpCmd = &cobra.Command{
+	Use:   "rsvp <accepted|declined|tentative> [number or id]",
+	Short: "Respond to an event invitation",
+	Long: `Sets your RSVP status on an event invitation.
+
+The first argument is your response: accepted, declined, or tentative
+(aliases: yes/no/maybe). The second selects the event — a row number from the
+last listing or a full/partial event ID. With no event argument, an
+interactive picker is shown.
+
+On a server-backed calendar (iCloud, Exchange, Google) this sends your reply
+to the organizer.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		status, err := parseRSVPStatus(args[0])
+		if err != nil {
+			return err
+		}
+
+		client, err := calendar.New()
+		if err != nil {
+			return handleClientError(err)
+		}
+		if !client.RSVPSupported() {
+			return fmt.Errorf("RSVP is not supported on this macOS version")
+		}
+
+		var event *calendar.Event
+		if len(args) == 2 {
+			event, err = findEventByPrefix(client, args[1])
+		} else {
+			event, err = pickEvent(client, "", "", 7)
+		}
+		if err != nil {
+			return err
+		}
+		if event == nil {
+			return nil // cancelled
+		}
+
+		if err := client.RespondToInvitation(event.ID, status); err != nil {
+			return fmt.Errorf("failed to RSVP: %w", err)
+		}
+		fmt.Printf("RSVP'd %s to %q\n", status, event.Title)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rsvpCmd)
+}
+
+// parseRSVPStatus maps a user-facing response word to a ParticipantStatus.
+func parseRSVPStatus(s string) (calendar.ParticipantStatus, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "accepted", "accept", "yes", "y":
+		return calendar.ParticipantStatusAccepted, nil
+	case "declined", "decline", "no", "n":
+		return calendar.ParticipantStatusDeclined, nil
+	case "tentative", "maybe", "m":
+		return calendar.ParticipantStatusTentative, nil
+	default:
+		return 0, fmt.Errorf("invalid RSVP response %q (use accepted, declined, or tentative)", s)
+	}
+}

--- a/cmd/ical/commands/scheduling_test.go
+++ b/cmd/ical/commands/scheduling_test.go
@@ -1,0 +1,183 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+)
+
+func timeAtHour(h int) time.Time {
+	return time.Date(2026, 6, 11, h, 0, 0, 0, time.UTC)
+}
+
+func TestParseAttendees(t *testing.T) {
+	tests := []struct {
+		name      string
+		invites   []string
+		want      []calendar.AttendeeInput
+		wantError bool
+	}{
+		{"nil", nil, nil, false},
+		{"bare email", []string{"a@x.com"}, []calendar.AttendeeInput{{Email: "a@x.com"}}, false},
+		{"named", []string{"Alice <a@x.com>"}, []calendar.AttendeeInput{{Name: "Alice", Email: "a@x.com"}}, false},
+		{"named with spaces", []string{"  Bob Smith  <b@y.com> "}, []calendar.AttendeeInput{{Name: "Bob Smith", Email: "b@y.com"}}, false},
+		{
+			"multiple mixed",
+			[]string{"a@x.com", "Carol <c@z.com>"},
+			[]calendar.AttendeeInput{{Email: "a@x.com"}, {Name: "Carol", Email: "c@z.com"}},
+			false,
+		},
+		{"no at sign", []string{"notanemail"}, nil, true},
+		{"empty angle brackets", []string{"Name <>"}, nil, true},
+		{"name without email no at", []string{"Just A Name"}, nil, true},
+		// Extreme / commonly-overlooked cases:
+		{"plus addressing", []string{"sidd+cal@x.com"}, []calendar.AttendeeInput{{Email: "sidd+cal@x.com"}}, false},
+		{"unicode display name", []string{"Сидд <s@x.com>"}, []calendar.AttendeeInput{{Name: "Сидд", Email: "s@x.com"}}, false},
+		{"subdomain multi-tld", []string{"Team <team@sub.x.co.uk>"}, []calendar.AttendeeInput{{Name: "Team", Email: "team@sub.x.co.uk"}}, false},
+		{"leading/trailing whitespace bare", []string{"   a@x.com   "}, []calendar.AttendeeInput{{Email: "a@x.com"}}, false},
+		{"bracket-only no name (paste format)", []string{"<a@x.com>"}, []calendar.AttendeeInput{{Email: "a@x.com"}}, false},
+		{"empty string entry", []string{""}, nil, true},
+		{"whitespace-only entry", []string{"   "}, nil, true},
+		{"name with @ but empty brackets still errors", []string{"a@b.com <>"}, nil, true},
+		{"second entry invalid fails whole batch", []string{"a@x.com", "bogus"}, nil, true},
+		// The overlooked footgun: comma/space-packed addresses in one value
+		// must fail loudly, not silently become one malformed attendee.
+		{"comma-packed addresses rejected", []string{"a@x.com,b@y.com"}, nil, true},
+		{"space-packed addresses rejected", []string{"a@x.com b@y.com"}, nil, true},
+		{"semicolon-packed rejected", []string{"a@x.com;b@y.com"}, nil, true},
+		{"double at rejected", []string{"a@@x.com"}, nil, true},
+		{"no dot in domain rejected", []string{"a@localhost"}, nil, true},
+		{"trailing dot domain rejected", []string{"a@x."}, nil, true},
+		{"leading dot domain rejected", []string{"a@.com"}, nil, true},
+		{"empty local part rejected", []string{"@x.com"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAttendees(tt.invites)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d attendees, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("attendee %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitNameEmail(t *testing.T) {
+	tests := []struct {
+		raw       string
+		wantName  string
+		wantEmail string
+	}{
+		{"a@x.com", "", "a@x.com"},
+		{"Alice <a@x.com>", "Alice", "a@x.com"},
+		{"  Bob  <b@y.com>  ", "Bob", "b@y.com"},
+		{"weird <name> <e@z.com>", "weird <name>", "e@z.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			name, email := splitNameEmail(tt.raw)
+			if name != tt.wantName || email != tt.wantEmail {
+				t.Errorf("got (%q, %q), want (%q, %q)", name, email, tt.wantName, tt.wantEmail)
+			}
+		})
+	}
+}
+
+func TestParseRSVPStatus(t *testing.T) {
+	tests := []struct {
+		in        string
+		want      calendar.ParticipantStatus
+		wantError bool
+	}{
+		{"accepted", calendar.ParticipantStatusAccepted, false},
+		{"accept", calendar.ParticipantStatusAccepted, false},
+		{"yes", calendar.ParticipantStatusAccepted, false},
+		{"Y", calendar.ParticipantStatusAccepted, false},
+		{"declined", calendar.ParticipantStatusDeclined, false},
+		{"no", calendar.ParticipantStatusDeclined, false},
+		{"tentative", calendar.ParticipantStatusTentative, false},
+		{"maybe", calendar.ParticipantStatusTentative, false},
+		{"  ACCEPTED  ", calendar.ParticipantStatusAccepted, false},
+		{"garbage", 0, true},
+		{"", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := parseRSVPStatus(tt.in)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error for %q", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBusySpans(t *testing.T) {
+	mk := func(typ calendar.AvailabilityType, hour int) calendar.AvailabilitySpan {
+		return calendar.AvailabilitySpan{Type: typ, Start: timeAtHour(hour), End: timeAtHour(hour + 1)}
+	}
+	t.Run("drops free, keeps busy/tentative/unavailable", func(t *testing.T) {
+		spans := []calendar.AvailabilitySpan{
+			mk(calendar.AvailabilityTypeFree, 9),
+			mk(calendar.AvailabilityTypeBusy, 10),
+			mk(calendar.AvailabilityTypeTentative, 11),
+			mk(calendar.AvailabilityTypeUnavailable, 12),
+		}
+		got := filterBusySpans(spans)
+		if len(got) != 3 {
+			t.Fatalf("got %d, want 3", len(got))
+		}
+	})
+	t.Run("sorts by start", func(t *testing.T) {
+		spans := []calendar.AvailabilitySpan{
+			mk(calendar.AvailabilityTypeBusy, 14),
+			mk(calendar.AvailabilityTypeBusy, 9),
+			mk(calendar.AvailabilityTypeBusy, 11),
+		}
+		got := filterBusySpans(spans)
+		if !got[0].Start.Before(got[1].Start) || !got[1].Start.Before(got[2].Start) {
+			t.Error("not sorted ascending by start")
+		}
+	})
+	t.Run("all free yields empty", func(t *testing.T) {
+		got := filterBusySpans([]calendar.AvailabilitySpan{mk(calendar.AvailabilityTypeFree, 9)})
+		if len(got) != 0 {
+			t.Errorf("got %d, want 0", len(got))
+		}
+	})
+	t.Run("nil input", func(t *testing.T) {
+		if got := filterBusySpans(nil); len(got) != 0 {
+			t.Errorf("got %d, want 0", len(got))
+		}
+	})
+	t.Run("identical starts keep stable order", func(t *testing.T) {
+		a := calendar.AvailabilitySpan{Type: calendar.AvailabilityTypeBusy, Start: timeAtHour(9), End: timeAtHour(10)}
+		b := calendar.AvailabilitySpan{Type: calendar.AvailabilityTypeTentative, Start: timeAtHour(9), End: timeAtHour(11)}
+		got := filterBusySpans([]calendar.AvailabilitySpan{a, b})
+		if got[0].Type != calendar.AvailabilityTypeBusy || got[1].Type != calendar.AvailabilityTypeTentative {
+			t.Error("stable order on equal starts not preserved")
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/ical
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.14.0
+	github.com/BRO3886/go-eventkit v0.15.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/fatih/color v1.18.0
 	github.com/mattn/go-runewidth v0.0.19

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BRO3886/go-eventkit v0.14.0 h1:7ZLru98CSE2q6d899C0FrT6QFEZ6Fvcpi1jf+N1hlY0=
-github.com/BRO3886/go-eventkit v0.14.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
+github.com/BRO3886/go-eventkit v0.15.0 h1:3A0D9jkS6O4U1WALJG+DpIDx0B5L4rdBWlkZL7UxDkE=
+github.com/BRO3886/go-eventkit v0.15.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -77,7 +77,7 @@ func PrintCalendars(calendars []calendar.Calendar, format string) {
 func PrintEventDetail(event *calendar.Event, format string) {
 	switch format {
 	case "json":
-		data, _ := json.MarshalIndent(event, "", "  ")
+		data, _ := json.MarshalIndent(toEventJSON(*event), "", "  ")
 		fmt.Println(string(data))
 	case "plain":
 		printEventDetailPlain(event, os.Stdout)
@@ -148,6 +148,8 @@ type eventJSON struct {
 	Notes              string                        `json:"notes,omitempty"`
 	URL                string                        `json:"url,omitempty"`
 	ConferenceURL      string                        `json:"conference_url,omitempty"`
+	TravelTime         string                        `json:"travel_time,omitempty"`
+	SelfStatus         string                        `json:"self_status,omitempty"`
 	Status             string                        `json:"status"`
 	Availability       string                        `json:"availability"`
 	Organizer          string                        `json:"organizer,omitempty"`
@@ -174,6 +176,8 @@ func toEventJSON(e calendar.Event) eventJSON {
 		Notes:              e.Notes,
 		URL:                e.URL,
 		ConferenceURL:      e.ConferenceURL,
+		TravelTime:         travelTimeJSON(e.TravelTime),
+		SelfStatus:         selfStatusJSON(e.SelfStatus),
 		Status:             e.Status.String(),
 		Availability:       e.Availability.String(),
 		Organizer:          e.Organizer,
@@ -330,6 +334,16 @@ func printEventDetailTable(e *calendar.Event, w io.Writer) {
 		fmt.Fprintln(w, color.HiGreenString(e.ConferenceURL))
 	}
 
+	if e.TravelTime > 0 {
+		bold.Fprintf(w, "Travel Time:  ")
+		fmt.Fprintln(w, formatTravelTime(e.TravelTime))
+	}
+
+	if e.SelfStatus != calendar.ParticipantStatusUnknown {
+		bold.Fprintf(w, "My RSVP:      ")
+		fmt.Fprintln(w, e.SelfStatus.String())
+	}
+
 	if e.Notes != "" {
 		bold.Fprintf(w, "Notes:        ")
 		fmt.Fprintln(w, e.Notes)
@@ -413,10 +427,47 @@ func printEventDetailPlain(e *calendar.Event, w io.Writer) {
 	if e.ConferenceURL != "" {
 		fmt.Fprintf(w, "Conference: %s\n", e.ConferenceURL)
 	}
+	if e.TravelTime > 0 {
+		fmt.Fprintf(w, "Travel Time: %s\n", formatTravelTime(e.TravelTime))
+	}
+	if e.SelfStatus != calendar.ParticipantStatusUnknown {
+		fmt.Fprintf(w, "My RSVP: %s\n", e.SelfStatus.String())
+	}
 	if e.Notes != "" {
 		fmt.Fprintf(w, "Notes: %s\n", e.Notes)
 	}
 	fmt.Fprintf(w, "ID: %s\n", e.ID)
+}
+
+// formatTravelTime renders a travel-time duration compactly (e.g. "30m", "1h30m").
+func formatTravelTime(d time.Duration) string {
+	d = d.Round(time.Minute)
+	h := d / time.Hour
+	m := (d % time.Hour) / time.Minute
+	switch {
+	case h > 0 && m > 0:
+		return fmt.Sprintf("%dh%dm", h, m)
+	case h > 0:
+		return fmt.Sprintf("%dh", h)
+	default:
+		return fmt.Sprintf("%dm", m)
+	}
+}
+
+// travelTimeJSON renders travel time for JSON output, empty when zero.
+func travelTimeJSON(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return formatTravelTime(d)
+}
+
+// selfStatusJSON renders the user's RSVP status for JSON output, empty when unknown.
+func selfStatusJSON(s calendar.ParticipantStatus) string {
+	if s == calendar.ParticipantStatusUnknown {
+		return ""
+	}
+	return s.String()
 }
 
 // FormatRecurrenceRule returns a human-readable recurrence description.

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/BRO3886/go-eventkit"
 	"github.com/BRO3886/go-eventkit/calendar"
+	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/fatih/color"
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/olekukonko/tablewriter"
@@ -136,30 +136,32 @@ func printEventsTable(events []calendar.Event, w io.Writer) {
 // Events — JSON
 
 type eventJSON struct {
-	ID                 string                        `json:"id"`
-	Title              string                        `json:"title"`
-	StartDate          time.Time                     `json:"start_date"`
-	EndDate            time.Time                     `json:"end_date"`
-	AllDay             bool                          `json:"all_day"`
-	Calendar           string                        `json:"calendar"`
-	CalendarID         string                        `json:"calendar_id"`
-	Location           string                        `json:"location,omitempty"`
-	StructuredLocation *eventkit.StructuredLocation   `json:"structured_location,omitempty"`
-	Notes              string                        `json:"notes,omitempty"`
-	URL                string                        `json:"url,omitempty"`
-	ConferenceURL      string                        `json:"conference_url,omitempty"`
-	TravelTime         string                        `json:"travel_time,omitempty"`
-	SelfStatus         string                        `json:"self_status,omitempty"`
-	Status             string                        `json:"status"`
-	Availability       string                        `json:"availability"`
-	Organizer          string                        `json:"organizer,omitempty"`
-	Attendees          []calendar.Attendee           `json:"attendees,omitempty"`
-	Recurring          bool                          `json:"recurring"`
-	RecurrenceRules    []eventkit.RecurrenceRule     `json:"recurrence_rules,omitempty"`
-	Alerts             []calendar.Alert              `json:"alerts,omitempty"`
-	TimeZone           string                        `json:"timezone,omitempty"`
-	CreatedAt          time.Time                     `json:"created_at"`
-	ModifiedAt         time.Time                     `json:"modified_at"`
+	ID                 string                       `json:"id"`
+	Title              string                       `json:"title"`
+	StartDate          time.Time                    `json:"start_date"`
+	EndDate            time.Time                    `json:"end_date"`
+	AllDay             bool                         `json:"all_day"`
+	Calendar           string                       `json:"calendar"`
+	CalendarID         string                       `json:"calendar_id"`
+	Location           string                       `json:"location,omitempty"`
+	StructuredLocation *eventkit.StructuredLocation `json:"structured_location,omitempty"`
+	Notes              string                       `json:"notes,omitempty"`
+	URL                string                       `json:"url,omitempty"`
+	ConferenceURL      string                       `json:"conference_url,omitempty"`
+	TravelTime         string                       `json:"travel_time,omitempty"`
+	SelfStatus         string                       `json:"self_status,omitempty"`
+	Status             string                       `json:"status"`
+	Availability       string                       `json:"availability"`
+	Organizer          string                       `json:"organizer,omitempty"`
+	Attendees          []calendar.Attendee          `json:"attendees,omitempty"`
+	Recurring          bool                         `json:"recurring"`
+	RecurrenceRules    []eventkit.RecurrenceRule    `json:"recurrence_rules,omitempty"`
+	IsDetached         bool                         `json:"is_detached,omitempty"`
+	OccurrenceDate     *time.Time                   `json:"occurrence_date,omitempty"`
+	Alerts             []calendar.Alert             `json:"alerts,omitempty"`
+	TimeZone           string                       `json:"timezone,omitempty"`
+	CreatedAt          time.Time                    `json:"created_at"`
+	ModifiedAt         time.Time                    `json:"modified_at"`
 }
 
 func toEventJSON(e calendar.Event) eventJSON {
@@ -184,6 +186,8 @@ func toEventJSON(e calendar.Event) eventJSON {
 		Attendees:          e.Attendees,
 		Recurring:          e.Recurring,
 		RecurrenceRules:    e.RecurrenceRules,
+		IsDetached:         e.IsDetached,
+		OccurrenceDate:     e.OccurrenceDate,
 		Alerts:             e.Alerts,
 		TimeZone:           e.TimeZone,
 		CreatedAt:          e.CreatedAt,

--- a/internal/ui/scheduling_test.go
+++ b/internal/ui/scheduling_test.go
@@ -1,0 +1,57 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BRO3886/go-eventkit/calendar"
+)
+
+func TestFormatTravelTime(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Minute, "30m"},
+		{time.Hour, "1h"},
+		{90 * time.Minute, "1h30m"},
+		{2 * time.Hour, "2h"},
+		{45*time.Minute + 30*time.Second, "46m"}, // rounds to nearest minute
+		{5 * time.Minute, "5m"},
+		// Overlooked boundaries:
+		{30 * time.Second, "1m"},          // rounds up to 1m
+		{29 * time.Second, "0m"},          // rounds down — sub-30s shows 0m (documented)
+		{25 * time.Hour, "25h"},           // beyond Apple's presets, still formats
+		{time.Hour + time.Minute, "1h1m"}, // singular-minute tail
+		{23*time.Hour + 59*time.Minute, "23h59m"},
+		{59 * time.Minute, "59m"}, // just under an hour stays in minutes
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := formatTravelTime(tt.d); got != tt.want {
+				t.Errorf("formatTravelTime(%v) = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTravelTimeJSON(t *testing.T) {
+	if got := travelTimeJSON(0); got != "" {
+		t.Errorf("zero should be empty, got %q", got)
+	}
+	if got := travelTimeJSON(-time.Minute); got != "" {
+		t.Errorf("negative should be empty, got %q", got)
+	}
+	if got := travelTimeJSON(30 * time.Minute); got != "30m" {
+		t.Errorf("got %q, want 30m", got)
+	}
+}
+
+func TestSelfStatusJSON(t *testing.T) {
+	if got := selfStatusJSON(calendar.ParticipantStatusUnknown); got != "" {
+		t.Errorf("unknown should be empty, got %q", got)
+	}
+	if got := selfStatusJSON(calendar.ParticipantStatusAccepted); got != "accepted" {
+		t.Errorf("got %q, want accepted", got)
+	}
+}

--- a/internal/ui/scheduling_test.go
+++ b/internal/ui/scheduling_test.go
@@ -55,3 +55,19 @@ func TestSelfStatusJSON(t *testing.T) {
 		t.Errorf("got %q, want accepted", got)
 	}
 }
+
+// TestToEventJSON_PreservesDetachedFields guards against a regression where
+// routing `show -o json` through eventJSON dropped isDetached/occurrenceDate
+// that the old raw-marshal path emitted (scripts use these to detect modified
+// occurrences of a recurring series).
+func TestToEventJSON_PreservesDetachedFields(t *testing.T) {
+	occ := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
+	e := calendar.Event{ID: "x", IsDetached: true, OccurrenceDate: &occ}
+	j := toEventJSON(e)
+	if !j.IsDetached {
+		t.Error("IsDetached lost in conversion")
+	}
+	if j.OccurrenceDate == nil || !j.OccurrenceDate.Equal(occ) {
+		t.Errorf("OccurrenceDate lost: %v", j.OccurrenceDate)
+	}
+}


### PR DESCRIPTION
Adds the remaining scheduling features from #46, built on go-eventkit v0.15.0 (released; bumped from v0.14.0).

## New commands & flags

- **`ical add --invite "Name <email>"`** (repeatable) and **`--travel 30m`** — invite attendees and set travel time when creating an event. On a server-backed calendar, saving sends invitations. Errors if attendee writes aren't supported on this macOS.
- **`ical rsvp <accepted|declined|tentative> [event]`** — respond to an invitation (aliases yes/no/maybe). Event resolves by row number, ID, or interactive picker.
- **`ical free <email>...`** — free/busy lookup over a window (`--from`/`--to`, default next 24h). Requires an Exchange or Google Workspace account; iCloud doesn't support it.
- **`ical inbox`** — list pending invitations awaiting a response.
- `ical show` now displays Travel Time and "My RSVP"; JSON output gains `travel_time` and `self_status`.

## Notable fix

`show -o json` previously marshaled the raw `calendar.Event` (camelCase keys, durations as nanoseconds), while `list -o json` used the `eventJSON` struct (snake_case, formatted). The two JSON shapes disagreed. Both now go through `eventJSON`, so single-event and list JSON are consistent — this also fixes `conference_url` not appearing in `show -o json`.

## Testing

**Unit tests** — emphasis on overlooked cases:
- `parseAttendees`: plus-addressing, unicode display names, multi-label TLDs, bracket-only paste format, and crucially **comma/space/semicolon-packed addresses are rejected** (e.g. `--invite "a@x.com,b@y.com"`) rather than silently saved as one malformed attendee; double-@, dotless domain, leading/trailing-dot domain, empty local part.
- `formatTravelTime`: rounding boundaries (29s→0m, 30s→1m, 90s→2m), >24h values, singular-minute tails.
- `parseRSVPStatus`: all aliases, case/whitespace, invalid.
- `filterBusySpans`: free dropped, sort by start, stable order on equal starts.

**Smoke tests** (real Work calendar):
- created an event inviting two real external addresses (with the invitee's consent) plus a named-form invite; verified 3 attendees and 45m travel persisted, and the invitations were actually dispatched by the account.
- `show -o json` confirmed consistent (`travel_time: "45m"`, `self_status: "accepted"`).
- `free` returned real Workspace busy data and degraded gracefully (no error, "free for the whole window") for an iCloud address with no data.
- `inbox` returned cleanly with no pending invitations.
- smoke event deleted afterward.

Pre-existing `gofmt` drift on main is untouched; new files are gofmt-clean.
