### PR TITLE
Document the scheduling commands and refresh the agent skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ ical/
 │       ├── today.go             # Shortcut: today's events
 │       ├── upcoming.go          # Shortcut: next N days
 │       ├── search.go            # Search events
+│       ├── join.go              # Open conference link of current/next event
+│       ├── rsvp.go              # Respond to an invitation (accept/decline/tentative)
+│       ├── free.go              # Free/busy availability lookup
+│       ├── inbox.go             # List pending invitations
 │       ├── export.go            # Export events (JSON/CSV/ICS)
 │       ├── import.go            # Import events (JSON/CSV)
 │       └── skills.go            # AI agent skill management (install/uninstall/status)
@@ -94,6 +98,8 @@ ical/
 - Interactive mode (`-i`): add and update support guided huh forms
 - `ical skills install` writes embedded skill files to `~/.claude/skills/ical-cli/`, `~/.codex/skills/ical-cli/`, `~/.openclaw/skills/ical-cli/`, or `~/.agents/skills/ical-cli/`
 - **SKILL.md examples must be permission-allowlist compatible** (#43): Claude Code matches each `;`/`&&`-separated segment against `allowed-tools`, but `{ }` brace groups and `$(...)` substitutions are opaque and always prompt. Chain with plain `;`; every binary used in an example must be pre-approved in frontmatter (`Bash(ical *) Bash(echo *) Bash(jq *) Bash(xargs ical *)`). Bulk recipes pass all IDs to one `ical delete` (xargs without `-I`), never one process per event
+- **Scheduling commands rely on private EventKit bridges in go-eventkit (v0.15.0+)**: `join` (conference URL), `rsvp`/`add --invite` (attendee writes + RSVP), `free` (availability), `inbox` (invitations). All gate on `client.<Feature>Supported()` and surface `ErrUnsupportedFeature` if the private selectors are gone. Free/busy needs an Exchange/Google Workspace account — **iCloud sources don't support availability** (`constraintSupportsAvailabilityRequests == NO`), so test `free` against a Workspace address, not the Work (iCloud) calendar. `add --invite` auto-adds the organizer and **sends real invitation email on save** — only smoke-test with own/consented addresses
+- **`show -o json` and `list -o json` both route through `internal/ui.eventJSON`** (snake_case keys, formatted durations). When adding an `Event` field, add it to `eventJSON` + `toEventJSON` or it silently vanishes from `show -o json` (regression caught in #48: `isDetached`/`occurrenceDate` were dropped)
 - Background update check: goroutine in PersistentPreRun, 2s timeout, 24h cache at `~/.cache/ical/update-check`
 - `ICAL_NO_UPDATE_CHECK=1` disables update check; also skipped for json output, piped stdout, dev builds
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ ical delete
 | `ical update [# or id]`          | Update an event (`-i` for interactive)            |
 | `ical delete [# or id...]`       | Delete one or more events (interactive picker if no arg) |
 | `ical search [query]`            | Search events                                     |
+| `ical join [# or id]`            | Open the conference link of the current/next event |
+| `ical rsvp [status] [# or id]`   | Respond to an invitation (accepted/declined/tentative) |
+| `ical free [email...]`           | Free/busy availability lookup (Exchange/Workspace only) |
+| `ical inbox`                      | List pending event invitations                    |
 | `ical export`                     | Export events (JSON/CSV/ICS)                      |
 | `ical import [file]`             | Import events (JSON/CSV)                          |
 | `ical skills install`             | Install AI agent skill (Claude Code / Codex / OpenClaw) |
@@ -268,6 +272,36 @@ ical delete 2 --span future
 # Delete the entire recurring series
 ical delete 2 --span all
 ```
+
+## Invitations & Availability
+
+Invite people to events, respond to invitations, look up free/busy, and join meetings — all from the terminal.
+
+```bash
+# Invite attendees when creating an event (sends invitations on save)
+ical add "Design review" --start "tomorrow 3pm" --calendar Work \
+  --invite alice@example.com --invite "Bob <bob@example.com>"
+
+# Add travel time before an event
+ical add "Client visit" --start "friday 2pm" --travel 45m
+
+# Respond to an invitation
+ical rsvp accepted 3          # accept the event at row 3
+ical rsvp declined <id>       # decline by event ID
+ical rsvp tentative           # no event arg → interactive picker
+
+# Look up when people are free or busy
+ical free alice@example.com bob@example.com --from "monday 9am" --to "monday 6pm"
+
+# List invitations awaiting your response
+ical inbox
+
+# Open the conference link of the current or next meeting
+ical join                     # opens it in the browser
+ical join --print             # just the URL (pipe-friendly)
+```
+
+> **Note:** Inviting attendees makes the calendar account send a real invitation email on save — there is no dry-run. The organizer (you) is added automatically. Free/busy lookup (`ical free`) requires an Exchange or Google Workspace account; **iCloud does not support availability lookups**.
 
 ## Export & Import
 

--- a/skills/ical-cli/SKILL.md
+++ b/skills/ical-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ical-cli
-description: Manages macOS Calendar events and calendars from the terminal via the ical CLI. Full CRUD for events and calendars with natural-language dates, recurrence, alerts, interactive mode, and JSON/CSV/ICS import/export. Use when the user wants to interact with Apple Calendar from the command line, automate calendar workflows, or build scripts around macOS Calendar.
+description: Manages macOS Calendar events and calendars from the terminal via the ical CLI. Full CRUD for events and calendars with natural-language dates, recurrence, alerts, attendee invitations, RSVP, free/busy lookup, conference-link joining, and JSON/CSV/ICS import/export. Use when the user wants to interact with Apple Calendar from the command line, invite people to events, check availability, respond to invitations, or automate calendar workflows.
 license: MIT
 compatibility: Requires macOS with Calendar.app access and the ical CLI installed (https://ical.sidv.dev)
 allowed-tools: Bash(ical *) Bash(echo *) Bash(jq *) Bash(xargs ical *)
@@ -40,6 +40,12 @@ ical also accepts natural-language strings directly (`today`, `tomorrow`, `next 
 | "Find events about X" | `ical search "X" --from today --to "in 30 days"` |
 | "Events involving <person>" | `ical list --from today --to "in 14 days" --attendee <name>` |
 | "Show only one-off events" | `ical upcoming --days 7 --no-recurring` |
+| "Invite people to a meeting" | `ical add "title" --start X --calendar C --invite a@x.com --invite "Bob <b@y.com>"` |
+| "Join my next meeting / get the call link" | `ical join` (opens it) or `ical join --print` (just the URL) |
+| "Accept / decline / tentatively accept an invite" | `ical rsvp accepted\|declined\|tentative <row-number>` |
+| "When is <person> free / busy" | `ical free a@x.com --from X --to Y` (needs Exchange/Workspace, NOT iCloud) |
+| "What invitations am I waiting on" | `ical inbox` |
+| "Add travel time before an event" | `ical add "title" --start X --travel 30m` |
 | "List / create / rename / delete calendars" | `ical calendars [create\|update\|delete]` |
 | "Export / back up events" | `ical export --format json --output-file backup.json` |
 
@@ -81,7 +87,12 @@ Row numbers are cached to `~/.ical-last-list` and stay valid until the next list
 - **`--repeat-days` only applies to `--repeat weekly`.** With any other frequency the CLI errors out. The recurrence engine silently discards the days otherwise.
 - **Timezone abbreviations (EST, CDT, BST, IST...) are rejected** inside date strings. Use `--timezone America/New_York` instead, with IANA names.
 - **Event IDs are calendar-scoped.** The UUID before `:` is the calendar ID shared by every event in that calendar. Short prefixes cannot disambiguate events within one calendar — prefer row numbers or `--id "<full>"`.
-- **Attendees and organizers are read-only** (Apple EventKit limitation). `ical add` does not accept `--attendee`. The `--attendee` flag on list/search is a filter, not an invite.
+- **Inviting attendees sends real email.** `ical add --invite a@x.com` adds the person and the calendar account dispatches an invitation on save — there is no dry-run. Only invite addresses the user actually intends to notify. The organizer (the user) is added automatically, so a 1-invitee event shows 2 attendees.
+- **`--invite` is repeatable; one address per flag.** `--invite a@x.com --invite "Bob <b@y.com>"`. Do NOT pack multiple addresses into one value (`--invite "a@x.com,b@y.com"`) — that's rejected. Accepts a bare email or `Name <email>`.
+- **The `--attendee` flag on list/search is a read-only filter, not an invite.** Use `--invite` on `add` to invite.
+- **Free/busy (`ical free`) needs an Exchange or Google Workspace account.** iCloud does not support availability lookups, so `ical free` against an iCloud-only setup reports no supporting account. Querying an iCloud address returns "free for the whole window" (no data), not an error.
+- **`ical rsvp` only works on events that are invitations to you.** RSVPing your own event is a harmless no-op. Status words: `accepted`/`declined`/`tentative` (aliases `yes`/`no`/`maybe`).
+- **`ical inbox` invitations carry no stable ID** — you can't pass them to `rsvp` by reference. Respond via `ical rsvp <status>` (interactive picker) or find the event with `ical list` first and use its row number.
 - **Subscribed calendars and the Birthdays calendar are read-only.** Event creation against them fails.
 - **`--calendar` / `-c` is repeatable.** Pass multiple times to filter by several calendars: `ical list -c Work -c Personal`. Single `-c` is optimized server-side; multiple values filter client-side.
 - **Calendar-name matching on `--calendar` and `--exclude-calendar` is case-insensitive and whitespace-trimmed**, so `"  Work "` and `work` both match a calendar named `Work`.
@@ -96,7 +107,7 @@ All read commands accept `-o`:
 - `json` — ISO 8601 timestamps, full fields, safe for scripts and agents
 - `plain` — one event per line, grep-friendly
 
-**Event JSON fields**: `id`, `title`, `start_date`, `end_date`, `all_day`, `calendar`, `calendar_id`, `location`, `notes`, `url`, `status`, `availability`, `organizer`, `attendees`, `recurring`, `recurrence_rules`, `alerts`, `timezone`, `created_at`, `modified_at`.
+**Event JSON fields**: `id`, `title`, `start_date`, `end_date`, `all_day`, `calendar`, `calendar_id`, `location`, `notes`, `url`, `conference_url`, `travel_time`, `self_status`, `status`, `availability`, `organizer`, `attendees`, `recurring`, `recurrence_rules`, `is_detached`, `occurrence_date`, `alerts`, `timezone`, `created_at`, `modified_at`. `conference_url` is the detected meeting link; `travel_time` is a compact string (`"30m"`); `self_status` is your RSVP (`accepted`/`declined`/`tentative`) on invitations. `show -o json` and `list -o json` use the same field names.
 
 **Calendar JSON fields**: `id`, `title`, `type`, `color`, `source`, `readOnly`. Note the list key is `title`, not `name`.
 
@@ -108,7 +119,7 @@ All read commands accept `-o`:
 - Inside a recurrence rule, `frequency` is an **integer enum** (`0=daily`, `1=weekly`, `2=monthly`, `3=yearly`), not a string. Compare against the int.
 - `alerts[].relativeOffset` is a **negative nanosecond duration** for before-event alerts. 15 minutes before = `-900000000000`. Divide by `-1e9` for seconds, or use `((. / -1000000000) / 60)` in jq for minutes.
 - `attendees[].status` is an **integer**, not a string — unlike event-level `status` and `availability` which serialize as strings. Map the int yourself if you need a label.
-- `attendees` has no write path — the array is read-only no matter what you do with `ical add` or `ical update`.
+- `attendees` is populated by `--invite` on `ical add` (not `update`); you cannot *remove* an attendee through the CLI. `self_status` reflects your own RSVP and updates after `ical rsvp`.
 
 ## Interactive mode
 
@@ -196,8 +207,34 @@ ical search "temp" --from today --to "in 7 days" -o json \
 ical export --from today --to "in 7 days" --format ics --output-file week.ics
 ```
 
+## Scheduling: invites, RSVP, availability, conference links
+
+```bash
+# Invite people to a new meeting (sends invitations on save)
+ical add "Design review" --start "tomorrow 3pm" --calendar Work \
+  --invite alice@example.com --invite "Bob <bob@example.com>" --travel 30m
+
+# Respond to an invitation by row number (from a prior listing)
+ical rsvp accepted 3
+ical rsvp tentative            # no row number → interactive picker
+
+# Free/busy across people (Exchange/Google Workspace only — not iCloud)
+ical free alice@example.com bob@example.com --from "monday 9am" --to "monday 6pm"
+
+# Open the conference link of the current or next meeting
+ical join                      # opens it in the browser
+ical join --print              # prints just the URL (pipe-friendly)
+
+# See invitations awaiting a response
+ical inbox
+ical inbox -o json
+```
+
+`ical free` prints each person's busy blocks; an address with no busy periods shows "free for the whole window". `--invite` and `--travel` are NOT available in interactive (`-i`) mode — pass them on the command line.
+
 ## Limits
 
-- Attendee invites are not supported (EventKit is read-only for attendees).
+- Attendee invites send real email; there is no dry-run. You can add attendees but not remove them via the CLI.
+- Free/busy requires an Exchange or Google Workspace account; iCloud does not support it.
 - Subscribed and Birthdays calendars are read-only.
 - macOS only.

--- a/skills/ical-cli/references/commands.md
+++ b/skills/ical-cli/references/commands.md
@@ -210,7 +210,11 @@ ical add -i   # Interactive mode
 | `--repeat-count`    | —     | Number of occurrences                               | 0              |
 | `--repeat-days`     | —     | Days for weekly recurrence (e.g., mon,wed,fri)      | —              |
 | `--timezone`        | —     | IANA timezone (e.g., America/New_York)              | —              |
+| `--invite`          | —     | Invite an attendee (`email` or `"Name <email>"`) — repeatable; sends an invitation | — |
+| `--travel`          | —     | Travel time before the event (e.g., 30m, 1h)        | —              |
 | `--interactive`     | `-i`  | Interactive mode with guided prompts                | false          |
+
+`--invite` and `--travel` are not available with `-i`. Inviting an attendee makes the calendar account send a real invitation email on save, and the organizer (you) is added automatically.
 
 Aliases: `create`, `new`
 
@@ -314,6 +318,72 @@ ical find "lunch" -o json
 | `--limit`        | `-n`  | Max results (0 = unlimited)                | 0             |
 
 Aliases: `find`
+
+---
+
+## ical join
+
+Open the video-conference link of the current or next meeting. With no argument, picks the event most likely wanted: one happening now (most recently started wins), otherwise the soonest upcoming event with a link, searched `--days` ahead. With an argument, resolves a row number or event ID like `show`.
+
+```bash
+ical join                 # open the current/next meeting link in the browser
+ical join --print         # print just the URL (pipe-friendly, opens nothing)
+ical join 3               # join the event at row 3 of the last listing
+ical join -d 1            # only look 1 day ahead
+ical join -o json         # full event JSON instead of opening
+```
+
+| Flag      | Short | Description                                      | Default |
+| --------- | ----- | ------------------------------------------------ | ------- |
+| `--print` | `-p`  | Print the conference link instead of opening it  | false   |
+| `--days`  | `-d`  | How many days ahead to look for the next meeting | 7       |
+
+Links are detected for Zoom, Google Meet, Teams, FaceTime, Webex, Jitsi, Whereby, Chime, and GoToMeeting, whether in the event's URL field, location, or notes. An event with no link errors.
+
+---
+
+## ical rsvp
+
+Respond to an event invitation. The first argument is the response; the second optionally selects the event (row number or ID). With no event argument, an interactive picker over the next 90 days is shown. On a server-backed calendar this sends the reply to the organizer.
+
+```bash
+ical rsvp accepted 3       # accept the event at row 3
+ical rsvp declined <id>    # decline by event ID
+ical rsvp tentative        # pick interactively
+```
+
+Response words: `accepted`, `declined`, `tentative` (aliases `yes`/`no`/`maybe`). RSVPing your own (non-invitation) event is a harmless no-op.
+
+---
+
+## ical free
+
+Look up free/busy availability for one or more people over a window. **Requires an Exchange or Google Workspace account** — iCloud does not support availability lookups.
+
+```bash
+ical free alice@example.com
+ical free alice@example.com bob@example.com --from "monday 9am" --to "monday 6pm"
+```
+
+| Flag     | Short | Description                  | Default |
+| -------- | ----- | ---------------------------- | ------- |
+| `--from` | `-f`  | Start of the window          | now     |
+| `--to`   | `-t`  | End of the window            | +24h    |
+
+Prints each person's busy blocks; an address with no busy periods (or one whose server returns nothing, e.g. an iCloud address) shows "free for the whole window".
+
+---
+
+## ical inbox
+
+List event invitations awaiting your response (the Calendar.app notification inbox).
+
+```bash
+ical inbox
+ical inbox -o json
+```
+
+No flags beyond the global `--output`. Invitations carry no stable ID, so respond via `ical rsvp <status>` (interactive picker), or find the event with `ical list` and use its row number.
 
 ---
 

--- a/website/content/docs/architecture.md
+++ b/website/content/docs/architecture.md
@@ -110,7 +110,8 @@ EventKit returns all times in UTC. ical converts them to local time using the ev
 
 These are Apple-imposed constraints, not bugs:
 
-- **Attendees and organizer are read-only** — EventKit does not allow modifying attendee lists
+- **Attendees can be invited but not removed** — `ical add --invite` adds attendees (and sends invitations); there is no way to remove an attendee or change the organizer through the CLI
+- **Free/busy needs Exchange or Google Workspace** — iCloud accounts do not support availability lookups, so `ical free` cannot resolve iCloud addresses
 - **Subscribed calendars are read-only** — Cannot create or modify events in subscribed calendars
 - **Birthday calendars are read-only** — The Birthdays calendar is auto-generated
 - **macOS only** — EventKit is an Apple framework; ical exits gracefully on other platforms

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -23,6 +23,10 @@ ical provides commands for managing macOS Calendar events and calendars. Every c
 | `ical update [# or id]`          | Update an event                                   |
 | `ical delete [# or id]`          | Delete an event                                   |
 | `ical search [query]`            | Search events                                     |
+| `ical join [# or id]`            | Open the conference link of the current/next event |
+| `ical rsvp [status] [# or id]`   | Respond to an invitation (accepted/declined/tentative) |
+| `ical free [email...]`           | Free/busy availability lookup (Exchange/Workspace only) |
+| `ical inbox`                      | List pending event invitations                    |
 | `ical export`                     | Export events (JSON/CSV/ICS)                      |
 | `ical import [file]`             | Import events (JSON/CSV)                          |
 | `ical skills install`             | Install AI agent skill (Claude Code / Codex / OpenClaw / others) |
@@ -279,10 +283,14 @@ ical add -i
 | `--alert`         |       | Add alert before event (repeatable)        |
 | `--no-alert`      |       | Create with zero alerts (overrides calendar default alerts) |
 | `--timezone`      |       | Timezone (e.g., `America/New_York`)        |
+| `--invite`        |       | Invite an attendee (`email` or `"Name <email>"`) — repeatable; sends an invitation |
+| `--travel`        |       | Travel time before the event (e.g., `30m`, `1h`) |
 | `--repeat`        |       | Recurrence: `daily`, `weekly`, `monthly`, `yearly` |
 | `--repeat-days`   |       | Days for weekly recurrence (repeatable)    |
 | `--repeat-until`  |       | Recurrence end date (a bare date includes the whole day) |
 | `--interactive`   | `-i`  | Use guided interactive form                |
+
+`--invite` and `--travel` are not available in interactive (`-i`) mode. Inviting an attendee makes the calendar account send a real invitation email on save, and the organizer (you) is added automatically.
 
 ### Examples
 
@@ -430,6 +438,74 @@ ical search "meeting" -c Work -f "1 month ago" -t "in 1 month"
 | `--attendee`     | `-a`  | Filter by attendee or organizer name/email |
 | `--no-recurring` |       | Hide recurring events                      |
 | `--limit`        | `-n`  | Maximum number of results                  |
+
+---
+
+## ical join
+
+Open the video-conference link of the current or next meeting. With no argument, ical picks the event you most likely want to join: one happening now (most recently started wins), otherwise the soonest upcoming event with a link. With an argument, it resolves a row number or event ID like `show`.
+
+```bash
+ical join              # open the current/next meeting link in the browser
+ical join --print      # print just the URL (pipe-friendly)
+ical join 3            # join the event at row 3 of the last listing
+```
+
+### Flags
+
+| Flag      | Short | Description                                      |
+|-----------|-------|--------------------------------------------------|
+| `--print` | `-p`  | Print the conference link instead of opening it  |
+| `--days`  | `-d`  | How many days ahead to look for the next meeting |
+
+Links are detected for Zoom, Google Meet, Teams, FaceTime, Webex, Jitsi, Whereby, Chime, and GoToMeeting, whether in the event's URL field, location, or notes.
+
+---
+
+## ical rsvp
+
+Respond to an event invitation. The first argument is your response; the second optionally selects the event by row number or ID. With no event argument, an interactive picker is shown. On a server-backed calendar this sends the reply to the organizer.
+
+```bash
+ical rsvp accepted 3       # accept the event at row 3
+ical rsvp declined <id>    # decline by event ID
+ical rsvp tentative        # pick interactively
+```
+
+Response words: `accepted`, `declined`, `tentative` (aliases `yes`/`no`/`maybe`).
+
+---
+
+## ical free
+
+Look up free/busy availability for one or more people over a time range. **Requires an Exchange or Google Workspace account — iCloud does not support availability lookups.**
+
+```bash
+ical free alice@example.com
+ical free alice@example.com bob@example.com --from "monday 9am" --to "monday 6pm"
+```
+
+### Flags
+
+| Flag     | Short | Description         |
+|----------|-------|---------------------|
+| `--from` | `-f`  | Start of the window (default: now) |
+| `--to`   | `-t`  | End of the window (default: +24h)  |
+
+Each person's busy blocks are printed; an address with no busy periods shows "free for the whole window".
+
+---
+
+## ical inbox
+
+List event invitations awaiting your response (the Calendar notification inbox).
+
+```bash
+ical inbox
+ical inbox -o json
+```
+
+Invitations carry no stable ID — respond with `ical rsvp <status>` (interactive picker) or find the event with `ical list` and use its row number.
 
 ---
 


### PR DESCRIPTION
Documentation and agent-skill update for the scheduling commands shipped in v0.11.0–v0.12.0 (`join`, `rsvp`, `free`, `inbox`, `add --invite/--travel`). No code changes — docs and the embedded skill only.

## What changed

- **Agent skill** (`skills/ical-cli/`): corrected the now-wrong "attendees are read-only / invites not supported" content (reversed in v0.12.0). Added intent-table rows, gotchas (invites send real email, organizer auto-added so 1 invitee → 2 attendees, iCloud can't do free/busy, inbox items have no stable ID, comma-packed `--invite` rejected), a scheduling recipe block, updated the Event JSON field list, and full command reference entries in `references/commands.md`. SKILL.md stays at 240 lines (well under the 500-line guideline).
- **README.md**: new commands in the table + an "Invitations & Availability" section with the email-sending and iCloud-free/busy caveats.
- **website/content/docs**: `commands.md` gets the four command sections and the `--invite`/`--travel` flags; `architecture.md` Limitations corrected (attendees can be invited but not removed; free/busy needs Exchange/Workspace). Cloudflare Pages auto-deploys on `website/**`.
- **CLAUDE.md**: architecture tree + conventions for the new commands and the two durable constraints (iCloud no free/busy; add `Event` fields to `eventJSON` or they vanish from `show -o json`).

## Why a release

The skill is `go:embed`-ed into the binary, so shipping the corrected skill needs a binary release. Cutting **v0.12.1** (docs/skill only) — `ical version` will then flag the installed v0.10.0 skill as outdated and prompt `ical skills install`.

The skill edits follow my skill-creation best-practices doc: gotchas as the highest-value content (every correction from the build session added there), defaults-not-menus intent table, accurate environment facts over generic filler, long-tail flags pushed to `references/`.
