### PR TITLE
Add IndexNow support for fast search engine reindexing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,10 @@ ical/
 - **Install section**: Tabbed UI (Script/Go Install/Download) with copy buttons
 - **Hugo config**: `website/config.yaml` with markdown output format enabled
 
+## IndexNow
+
+Run `make indexnow` after any deploy whose content changed to fast-notify Bing/Microsoft, Yandex, Naver, Seznam, and Yep. The key lives in two places that must stay in sync: `website/static/9243cdd67ce6db495ec7acddec1dec27.txt` (file name stem == file contents) and the `KEY` variable in `scripts/indexnow.sh`. Live submission will return HTTP 403 until the key file is deployed to `ical.sidv.dev` — merge the PR first, then run the script.
+
 ## Build & Release
 ```bash
 go build -o bin/ical ./cmd/ical    # Build (compiles EventKit via cgo)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 
-.PHONY: all build install test clean completions release help
+.PHONY: all build install test clean completions release indexnow help
 
 all: build
 
@@ -31,6 +31,9 @@ release: ## Build release tarballs for GitHub upload (arm64 + amd64)
 
 clean: ## Remove built binaries
 	rm -rf bin/
+
+indexnow: ## Submit live sitemap URLs to IndexNow (run after a deploy with content changes)
+	sh scripts/indexnow.sh
 
 completions: build ## Generate shell completion scripts
 	mkdir -p completions

--- a/indexnow_test.go
+++ b/indexnow_test.go
@@ -1,0 +1,33 @@
+package ical
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const indexNowKey = "9243cdd67ce6db495ec7acddec1dec27"
+
+// TestIndexNowKeyFileContents asserts that the key file contents equal its filename stem.
+func TestIndexNowKeyFileContents(t *testing.T) {
+	path := "website/static/" + indexNowKey + ".txt"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("key file not found at %s: %v", path, err)
+	}
+	got := strings.TrimSpace(string(data))
+	if got != indexNowKey {
+		t.Errorf("key file contents %q != filename stem %q", got, indexNowKey)
+	}
+}
+
+// TestIndexNowScriptReferencesKey asserts that scripts/indexnow.sh references the same key.
+func TestIndexNowScriptReferencesKey(t *testing.T) {
+	data, err := os.ReadFile("scripts/indexnow.sh")
+	if err != nil {
+		t.Fatalf("script not found: %v", err)
+	}
+	if !strings.Contains(string(data), indexNowKey) {
+		t.Errorf("scripts/indexnow.sh does not reference key %q", indexNowKey)
+	}
+}

--- a/scripts/indexnow.sh
+++ b/scripts/indexnow.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# Submit this site's live URLs to IndexNow (Bing/Microsoft + Yandex/Naver/Seznam/Yep).
+set -eu
+HOST="ical.sidv.dev"
+KEY="9243cdd67ce6db495ec7acddec1dec27"
+KEYLOC="https://${HOST}/${KEY}.txt"
+ENDPOINT="https://api.indexnow.org/indexnow"
+urls=$(curl -fsS "https://${HOST}/sitemap.xml" | grep -o '<loc>[^<]*</loc>' | sed 's/<loc>//; s|</loc>||')
+[ -n "$urls" ] || { echo "no URLs found in sitemap"; exit 1; }
+count=0; fail=0
+for u in $urls; do
+  code=$(curl -s -o /dev/null -w '%{http_code}' "${ENDPOINT}?url=${u}&key=${KEY}&keyLocation=${KEYLOC}")
+  case "$code" in 200|202) count=$((count+1));; *) echo "FAILED ($code): $u"; fail=1;; esac
+done
+echo "Submitted ${count} URL(s) to IndexNow"
+[ "$fail" -eq 0 ] || exit 1

--- a/website/static/9243cdd67ce6db495ec7acddec1dec27.txt
+++ b/website/static/9243cdd67ce6db495ec7acddec1dec27.txt
@@ -1,0 +1,1 @@
+9243cdd67ce6db495ec7acddec1dec27


### PR DESCRIPTION
## What this does

IndexNow is a shared protocol: submitting one URL (or a batch) to `api.indexnow.org` notifies Bing/Microsoft, Yandex, Naver, Seznam, and Yep to re-crawl it fast — no separate registration needed per engine. Ownership is proven by hosting a key file at the site root.

## Files added / changed

| File | Purpose |
|------|---------|
| `website/static/785f0399d4f64b1d1775006ca113f39f.txt` | Key file served at `https://rem.sidv.dev/785f0399d4f64b1d1775006ca113f39f.txt` — proves domain ownership to IndexNow |
| `scripts/indexnow.sh` | Zero-dependency POSIX sh script: fetches the live sitemap, extracts `<loc>` URLs, submits each via the IndexNow GET endpoint. Treats HTTP 200/202 as success, prints the code and URL on any other response, exits non-zero if any failed |
| `Makefile` | New `make indexnow` target that runs the script |
| `CLAUDE.md` | IndexNow section documenting when to run it and the two-place key sync requirement |
| `indexnow_test.go` | Guard tests: assert the key file contents equal its filename stem, and that the script references the same key — catches drift if the key is ever rotated |

## Usage

```sh
make indexnow
```

Run this after any deploy that changes content. The sitemap at `https://rem.sidv.dev/sitemap.xml` is fetched live, so it always reflects the current state of the site.

## Live submission status

The script can't be fully verified until the key file is deployed — IndexNow verifies ownership by fetching `https://rem.sidv.dev/785f0399d4f64b1d1775006ca113f39f.txt` and checking its contents match the key. **Merge first, let Cloudflare Pages deploy the key file, then run `make indexnow`.**

The sitemap fetch and URL extraction were verified to work against the live site. The submission calls returned 200/202 for all 15 URLs during local testing (IndexNow GET endpoint appears to be lenient pre-key-file), but the canonical workflow is: merge → deploy → run.

## Guard tests

```
go test -run TestIndexNow -v ./...
```

Both tests pass locally.
