### PR TITLE
Refer to the app as Apple Calendar in titles and visible copy

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -1,10 +1,10 @@
 baseURL: "https://ical.sidv.dev/"
 languageCode: "en-us"
-title: "ical — CLI for macOS Calendar"
+title: "ical — CLI for Apple Calendar"
 theme: "cal-docs"
 
 params:
-  description: "A native macOS Calendar CLI built with Go and EventKit. 3000x faster than AppleScript. Full CRUD, natural language dates, recurrence, import/export, and multiple output formats."
+  description: "A native Apple Calendar CLI built with Go and EventKit. 3000x faster than AppleScript. Full CRUD, natural language dates, recurrence, import/export, and multiple output formats."
   author: "Siddharth Verma"
   github: "https://github.com/BRO3886/ical"
   ogImage: "/images/og-image.png"

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "ical — CLI for macOS Calendar"
-description: "A native macOS Calendar CLI built with Go and EventKit. 3000x faster than AppleScript. Full CRUD, natural language dates, recurrence, import/export, and multiple output formats."
+title: "ical — CLI for Apple Calendar"
+description: "A native Apple Calendar CLI built with Go and EventKit. 3000x faster than AppleScript. Full CRUD, natural language dates, recurrence, import/export, and multiple output formats."
 keywords: ["macOS Calendar CLI", "ical CLI", "command line calendar macOS", "Apple Calendar terminal", "EventKit Go", "macOS productivity tool", "Claude Code calendar skill", "Codex CLI calendar", "OpenClaw calendar skill", "AI agent calendar tool"]
 ---

--- a/website/themes/cal-docs/layouts/index.html
+++ b/website/themes/cal-docs/layouts/index.html
@@ -6,7 +6,7 @@
       <span class="hero-accent">From the terminal.</span>
     </h1>
     <p class="hero-subtitle fade-in delay-1">
-      A blazing fast CLI for macOS Calendar — built for humans and AI agents alike. Powered by <a href="https://github.com/BRO3886/go-eventkit" target="_blank" rel="noopener">go-eventkit</a>.
+      A blazing fast CLI for Apple Calendar — built for humans and AI agents alike. Powered by <a href="https://github.com/BRO3886/go-eventkit" target="_blank" rel="noopener">go-eventkit</a>.
     </p>
     <div class="hero-actions fade-in delay-2">
       <a href="{{ "docs/getting-started/" | relURL }}" class="btn btn-primary">Get Started</a>
@@ -41,7 +41,7 @@
 <section class="features">
   <div class="features-inner">
     <h2 class="section-title scroll-reveal">Designed for how you work</h2>
-    <p class="section-subtitle scroll-reveal">Manage your macOS Calendar entirely from the command line.</p>
+    <p class="section-subtitle scroll-reveal">Manage your Apple Calendar entirely from the command line.</p>
     <div class="feature-grid">
       <div class="feature-card scroll-reveal">
         <div class="feature-icon">

--- a/website/themes/cal-docs/layouts/partials/footer.html
+++ b/website/themes/cal-docs/layouts/partials/footer.html
@@ -2,7 +2,7 @@
   <div class="footer-inner">
     <div class="footer-brand">
       <span class="footer-logo">cal</span>
-      <p class="footer-tagline">A native CLI for macOS Calendar.</p>
+      <p class="footer-tagline">A native CLI for Apple Calendar.</p>
     </div>
     <div class="footer-links">
       <div class="footer-col">


### PR DESCRIPTION
Renames the prominent product references on the site from "macOS Calendar" to "Apple Calendar" — the app's actual product name. Scoped to the big-print / title and visible-copy surfaces, not the technical OS references.

## Changed
- Site title (`config.yaml`) and homepage `title` — now "ical — CLI for Apple Calendar"
- Homepage hero subtitle and the "Designed for how you work" section subtitle
- Footer tagline
- The matching homepage meta descriptions (`config.yaml` + `_index.md`)

## Left as macOS (genuine OS references, not the app name)
- Version requirements (`macOS 10.12+`), permission prompts, `EventKit`/Apple-framework mentions, the "local macOS Calendar store" wording, platform notes, and the FAQ/architecture docs body
- SEO keyword arrays — these already include both "macOS Calendar CLI" and "Apple Calendar terminal" on purpose

## Verification
`hugo` builds clean; rendered `public/index.html` shows `<title>ical — CLI for Apple Calendar</title>`, the "Apple Calendar" hero subtitle, section subtitle, and footer tagline.
