### PR TITLE
fix(cli): suppress notices for json output

### DIFF
--- a/cmd/ical/commands/root.go
+++ b/cmd/ical/commands/root.go
@@ -91,7 +91,11 @@ func shouldCheckForUpdate(cmd *cobra.Command) bool {
 }
 
 // printUpdateNotice prints update and skills staleness notices to stderr.
-func printUpdateNotice(_ *cobra.Command) {
+func printUpdateNotice(cmd *cobra.Command) {
+	if !shouldShowPostRunNotices(cmd) {
+		return
+	}
+
 	// Collect update result (non-blocking — if goroutine isn't done, skip)
 	var result *update.Result
 	select {
@@ -116,6 +120,28 @@ func printUpdateNotice(_ *cobra.Command) {
 
 	// Check skills staleness (local only, no HTTP)
 	printSkillsStalenessNotice(homeDir)
+}
+
+// shouldShowPostRunNotices returns false when notices would pollute scripted output.
+func shouldShowPostRunNotices(cmd *cobra.Command) bool {
+	if os.Getenv("ICAL_NO_UPDATE_CHECK") != "" {
+		return false
+	}
+
+	name := cmd.Name()
+	if name == "version" || name == "completion" || name == "skills" {
+		return false
+	}
+
+	if outputFormat == "json" {
+		return false
+	}
+
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 // printSkillsStalenessNotice checks if installed skills are outdated.

--- a/cmd/ical/commands/root_test.go
+++ b/cmd/ical/commands/root_test.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BRO3886/ical/internal/update"
+)
+
+func TestPrintUpdateNoticeSkipsSkillsStalenessForJSONOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	skillDir := filepath.Join(tmpDir, ".claude", "skills", "ical-cli")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("test skill\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, ".ical-version"), []byte("v0.10.1\n"), 0o644); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+
+	oldOutputFormat := outputFormat
+	oldVersionStr := versionStr
+	oldUpdateResultCh := updateResultCh
+	oldStderr := os.Stderr
+	defer func() {
+		outputFormat = oldOutputFormat
+		versionStr = oldVersionStr
+		updateResultCh = oldUpdateResultCh
+		os.Stderr = oldStderr
+	}()
+
+	outputFormat = "json"
+	versionStr = "v0.10.2"
+	updateResultCh = make(chan *update.Result, 1)
+	updateResultCh <- nil
+
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = writeEnd
+
+	printUpdateNotice(rootCmd)
+
+	if err := writeEnd.Close(); err != nil {
+		t.Fatalf("close stderr pipe: %v", err)
+	}
+	got, err := io.ReadAll(readEnd)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if string(got) != "" {
+		t.Fatalf("stderr = %q, want empty for json output", got)
+	}
+}


### PR DESCRIPTION
Fixes #50.

## Summary
- skip post-run update and skills notices in JSON/scripted output contexts
- keep meta commands and piped stdout free of post-run notices
- add regression coverage for stale skills with `-o json`

## Tests
- `/opt/homebrew/bin/go test ./...`
