### PR TITLE
fix: reject event identifiers that do not round-trip

### DIFF
--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -149,7 +149,7 @@ var addCmd = &cobra.Command{
 			return fmt.Errorf("failed to create event: %w", err)
 		}
 
-		ui.PrintCreatedEvent(event)
+		ui.PrintCreatedEvent(event, outputFormat)
 		if len(input.Attendees) > 0 {
 			fmt.Printf("Invited %d attendee(s); invitations are sent by the calendar account.\n", len(input.Attendees))
 		}
@@ -464,7 +464,7 @@ func runAddInteractive() error {
 	}
 
 	fmt.Println()
-	ui.PrintCreatedEvent(event)
+	ui.PrintCreatedEvent(event, outputFormat)
 	return nil
 }
 

--- a/cmd/ical/commands/calendars.go
+++ b/cmd/ical/commands/calendars.go
@@ -116,7 +116,7 @@ Use -i for interactive mode with guided prompts.`,
 			return fmt.Errorf("failed to create calendar: %w", err)
 		}
 
-		ui.PrintCreatedCalendar(cal)
+		ui.PrintCreatedCalendar(cal, outputFormat)
 		return nil
 	},
 }
@@ -209,7 +209,7 @@ func runCalCreateInteractive() error {
 	}
 
 	fmt.Println()
-	ui.PrintCreatedCalendar(cal)
+	ui.PrintCreatedCalendar(cal, outputFormat)
 	return nil
 }
 
@@ -290,7 +290,7 @@ Use -i for interactive mode with guided prompts.`,
 			return fmt.Errorf("failed to update calendar: %w", err)
 		}
 
-		ui.PrintUpdatedCalendar(updated)
+		ui.PrintUpdatedCalendar(updated, outputFormat)
 		return nil
 	},
 }
@@ -372,7 +372,7 @@ func runCalUpdateInteractive(client *calendar.Client, cal *calendar.Calendar) er
 	}
 
 	fmt.Println()
-	ui.PrintUpdatedCalendar(updated)
+	ui.PrintUpdatedCalendar(updated, outputFormat)
 	return nil
 }
 

--- a/cmd/ical/commands/show.go
+++ b/cmd/ical/commands/show.go
@@ -77,14 +77,26 @@ func init() {
 	rootCmd.AddCommand(showCmd)
 }
 
+// eventLookup is the slice of *calendar.Client that findEventByPrefix needs.
+// Narrowing it keeps the resolver testable without a live EventKit store.
+type eventLookup interface {
+	Event(id string) (*calendar.Event, error)
+	Events(start, end time.Time, opts ...calendar.ListOption) ([]calendar.Event, error)
+}
+
 // findEventByPrefix finds an event by row number from the last listing,
 // by exact ID, or by ID prefix matching.
-func findEventByPrefix(client *calendar.Client, input string) (*calendar.Event, error) {
+//
+// Every lookup is checked for a round-trip: EventKit resolves a partial or
+// stale identifier to an arbitrary event instead of reporting no match, so an
+// event whose ID is not the one that was asked for is treated as no match at
+// all. Without that check, delete acts on whichever event EventKit picked.
+func findEventByPrefix(client eventLookup, input string) (*calendar.Event, error) {
 	// Check if input is a row number (e.g. "1", "2") from the last listing
 	if n, err := strconv.Atoi(input); err == nil && n > 0 {
 		if id := ui.LookupRowNumber(n); id != "" {
 			event, err := client.Event(id)
-			if err == nil {
+			if err == nil && event.ID == id {
 				return event, nil
 			}
 			// Event may have been deleted since listing; fall through to search
@@ -93,10 +105,10 @@ func findEventByPrefix(client *calendar.Client, input string) (*calendar.Event, 
 
 	// Try exact match
 	event, err := client.Event(input)
-	if err == nil {
+	if err == nil && event.ID == input {
 		return event, nil
 	}
-	if !errors.Is(err, calendar.ErrNotFound) {
+	if err != nil && !errors.Is(err, calendar.ErrNotFound) {
 		return nil, fmt.Errorf("failed to fetch event: %w", err)
 	}
 

--- a/cmd/ical/commands/show_test.go
+++ b/cmd/ical/commands/show_test.go
@@ -1,0 +1,131 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BRO3886/ical/internal/ui"
+	"github.com/BRO3886/go-eventkit/calendar"
+)
+
+// macOS event identifiers are "<store UUID>:<event UUID>", so every event in a
+// store shares a long leading run of characters. Anything derived from that run
+// alone - a truncated ID, a stale cache entry - identifies no single event.
+const (
+	storeUUID = "00000000-1111-2222-3333-444444444444"
+	idA       = storeUUID + ":AAAAAAAA-0000-0000-0000-00000000000A"
+	idB       = storeUUID + ":BBBBBBBB-0000-0000-0000-00000000000B"
+)
+
+// fakeLookup stands in for *calendar.Client. Its lenient field reproduces the
+// EventKit behaviour that makes the round-trip check necessary: an identifier
+// that matches nothing resolves to some unrelated event rather than failing.
+type fakeLookup struct {
+	byID    map[string]calendar.Event
+	all     []calendar.Event
+	lenient *calendar.Event
+}
+
+func (f *fakeLookup) Event(id string) (*calendar.Event, error) {
+	if e, ok := f.byID[id]; ok {
+		return &e, nil
+	}
+	if f.lenient != nil {
+		e := *f.lenient
+		return &e, nil
+	}
+	return nil, calendar.ErrNotFound
+}
+
+func (f *fakeLookup) Events(start, end time.Time, opts ...calendar.ListOption) ([]calendar.Event, error) {
+	return f.all, nil
+}
+
+func twoEventStore(lenient *calendar.Event) *fakeLookup {
+	a := calendar.Event{ID: idA, Title: "Interview - round 2"}
+	b := calendar.Event{ID: idB, Title: "Dentist"}
+	return &fakeLookup{
+		byID:    map[string]calendar.Event{idA: a, idB: b},
+		all:     []calendar.Event{a, b},
+		lenient: lenient,
+	}
+}
+
+// A truncated ID names no event. The resolver must say so rather than hand back
+// whatever EventKit resolved it to - delete acts on what this returns.
+func TestFindEventByPrefixRejectsLenientMatch(t *testing.T) {
+	stranger := calendar.Event{ID: storeUUID + ":CCCCCCCC-0000-0000-0000-00000000000C", Title: "Cancel broadband"}
+	client := twoEventStore(&stranger)
+
+	event, err := findEventByPrefix(client, storeUUID[:13])
+
+	if event != nil {
+		t.Fatalf("resolved an ambiguous ID to %q (%s); nothing should have matched", event.Title, event.ID)
+	}
+	if err == nil {
+		t.Fatal("expected an error for an ambiguous ID, got nil")
+	}
+	if !strings.Contains(err.Error(), "Multiple events match") {
+		t.Errorf("expected an ambiguity error, got %q", err)
+	}
+}
+
+// A stale row number points at an ID that no longer resolves. The lenient
+// lookup must not be allowed to substitute a different event for it.
+func TestFindEventByPrefixRejectsStaleRowNumber(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ui.SaveLastList([]calendar.Event{{ID: "DEAD0000-0000-0000-0000-000000000000:1"}})
+
+	stranger := calendar.Event{ID: idB, Title: "Dentist"}
+	client := twoEventStore(&stranger)
+
+	event, err := findEventByPrefix(client, "1")
+
+	if event != nil {
+		t.Fatalf("stale row number resolved to %q (%s)", event.Title, event.ID)
+	}
+	if err == nil {
+		t.Fatal("expected an error for a stale row number, got nil")
+	}
+}
+
+func TestFindEventByPrefixExactID(t *testing.T) {
+	client := twoEventStore(nil)
+
+	event, err := findEventByPrefix(client, idA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.ID != idA {
+		t.Errorf("got %s, want %s", event.ID, idA)
+	}
+}
+
+// A prefix that reaches into the event-specific half is unambiguous, so prefix
+// matching still works - the fix narrows the resolver, it does not disable it.
+func TestFindEventByPrefixUniquePrefix(t *testing.T) {
+	client := twoEventStore(nil)
+
+	event, err := findEventByPrefix(client, storeUUID+":AAAA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.ID != idA {
+		t.Errorf("got %s, want %s", event.ID, idA)
+	}
+}
+
+func TestFindEventByPrefixNoMatch(t *testing.T) {
+	stranger := calendar.Event{ID: idB, Title: "Dentist"}
+	client := twoEventStore(&stranger)
+
+	event, err := findEventByPrefix(client, "no-such-event")
+
+	if event != nil {
+		t.Fatalf("unknown ID resolved to %q (%s)", event.Title, event.ID)
+	}
+	if err == nil || !strings.Contains(err.Error(), "no event found") {
+		t.Errorf("expected a not-found error, got %v", err)
+	}
+}

--- a/cmd/ical/commands/update.go
+++ b/cmd/ical/commands/update.go
@@ -230,7 +230,7 @@ func runUpdateInteractive(client *calendar.Client, event *calendar.Event) error 
 		return fmt.Errorf("no writable calendars found")
 	}
 
-	fmt.Printf("Editing: %s (ID: %s)\n\n", event.Title, ui.ShortID(event.ID))
+	fmt.Printf("Editing: %s (ID: %s)\n\n", event.Title, event.ID)
 
 	// Page 1: Core fields
 	core := huh.NewGroup(

--- a/cmd/ical/commands/update.go
+++ b/cmd/ical/commands/update.go
@@ -174,7 +174,7 @@ Use -i for interactive mode with guided prompts.`,
 			return fmt.Errorf("failed to update event: %w", err)
 		}
 
-		ui.PrintUpdatedEvent(updated)
+		ui.PrintUpdatedEvent(updated, outputFormat)
 		return nil
 	},
 }
@@ -423,7 +423,7 @@ func runUpdateInteractive(client *calendar.Client, event *calendar.Event) error 
 	}
 
 	fmt.Println()
-	ui.PrintUpdatedEvent(updated)
+	ui.PrintUpdatedEvent(updated, outputFormat)
 	return nil
 }
 

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -640,16 +640,6 @@ func truncate(s string, max int) string {
 	return runewidth.Truncate(s, max, "...")
 }
 
-// ShortID returns the first 13 chars of an event ID.
-// This covers two UUID segments (e.g. "577B8983-DF44") which is
-// enough to disambiguate events from the same source.
-func ShortID(id string) string {
-	if len(id) <= 13 {
-		return id
-	}
-	return id[:13]
-}
-
 // PrintCreatedEvent prints summary info for a newly created event.
 func PrintCreatedEvent(e *calendar.Event) {
 	start := localizeTime(e.StartDate, e.TimeZone)
@@ -659,7 +649,7 @@ func PrintCreatedEvent(e *calendar.Event) {
 	fmt.Printf("%s\n", e.Title)
 	fmt.Printf("  Calendar: %s\n", e.Calendar)
 	fmt.Printf("  When:     %s\n", dateparser.FormatTimeRange(start, end, e.AllDay))
-	fmt.Printf("  ID:       %s\n", ShortID(e.ID))
+	fmt.Printf("  ID:       %s\n", e.ID)
 }
 
 // PrintCreatedCalendar prints summary info for a newly created calendar.
@@ -695,5 +685,5 @@ func PrintUpdatedEvent(e *calendar.Event) {
 	fmt.Printf("%s\n", e.Title)
 	fmt.Printf("  Calendar: %s\n", e.Calendar)
 	fmt.Printf("  When:     %s\n", dateparser.FormatTimeRange(start, end, e.AllDay))
-	fmt.Printf("  ID:       %s\n", ShortID(e.ID))
+	fmt.Printf("  ID:       %s\n", e.ID)
 }

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -641,49 +641,58 @@ func truncate(s string, max int) string {
 }
 
 // PrintCreatedEvent prints summary info for a newly created event.
-func PrintCreatedEvent(e *calendar.Event) {
-	start := localizeTime(e.StartDate, e.TimeZone)
-	end := localizeTime(e.EndDate, e.TimeZone)
-	green := color.New(color.FgGreen, color.Bold)
-	green.Print("Created: ")
-	fmt.Printf("%s\n", e.Title)
-	fmt.Printf("  Calendar: %s\n", e.Calendar)
-	fmt.Printf("  When:     %s\n", dateparser.FormatTimeRange(start, end, e.AllDay))
-	fmt.Printf("  ID:       %s\n", e.ID)
-}
-
-// PrintCreatedCalendar prints summary info for a newly created calendar.
-func PrintCreatedCalendar(c *calendar.Calendar) {
-	green := color.New(color.FgGreen, color.Bold)
-	green.Print("Created: ")
-	fmt.Printf("%s\n", c.Title)
-	fmt.Printf("  Source: %s\n", c.Source)
-	if c.Color != "" {
-		fmt.Printf("  Color:  %s\n", c.Color)
-	}
-	fmt.Printf("  ID:     %s\n", c.ID)
-}
-
-// PrintUpdatedCalendar prints summary info for an updated calendar.
-func PrintUpdatedCalendar(c *calendar.Calendar) {
-	green := color.New(color.FgGreen, color.Bold)
-	green.Print("Updated: ")
-	fmt.Printf("%s\n", c.Title)
-	fmt.Printf("  Source: %s\n", c.Source)
-	if c.Color != "" {
-		fmt.Printf("  Color:  %s\n", c.Color)
-	}
-	fmt.Printf("  ID:     %s\n", c.ID)
+func PrintCreatedEvent(e *calendar.Event, format string) {
+	writeEventResult(os.Stdout, e, format, "Created: ")
 }
 
 // PrintUpdatedEvent prints summary info for an updated event.
-func PrintUpdatedEvent(e *calendar.Event) {
+func PrintUpdatedEvent(e *calendar.Event, format string) {
+	writeEventResult(os.Stdout, e, format, "Updated: ")
+}
+
+// writeEventResult reports a created or updated event. Under -o json it emits
+// the object shape show emits, so a script that creates an event can read the
+// result the same way it reads every other command's output.
+func writeEventResult(w io.Writer, e *calendar.Event, format, label string) {
+	if format == "json" {
+		data, _ := json.MarshalIndent(toEventJSON(*e), "", "  ")
+		fmt.Fprintln(w, string(data))
+		return
+	}
+
 	start := localizeTime(e.StartDate, e.TimeZone)
 	end := localizeTime(e.EndDate, e.TimeZone)
 	green := color.New(color.FgGreen, color.Bold)
-	green.Print("Updated: ")
-	fmt.Printf("%s\n", e.Title)
-	fmt.Printf("  Calendar: %s\n", e.Calendar)
-	fmt.Printf("  When:     %s\n", dateparser.FormatTimeRange(start, end, e.AllDay))
-	fmt.Printf("  ID:       %s\n", e.ID)
+	green.Fprint(w, label)
+	fmt.Fprintf(w, "%s\n", e.Title)
+	fmt.Fprintf(w, "  Calendar: %s\n", e.Calendar)
+	fmt.Fprintf(w, "  When:     %s\n", dateparser.FormatTimeRange(start, end, e.AllDay))
+	fmt.Fprintf(w, "  ID:       %s\n", e.ID)
+}
+
+// PrintCreatedCalendar prints summary info for a newly created calendar.
+func PrintCreatedCalendar(c *calendar.Calendar, format string) {
+	writeCalendarResult(os.Stdout, c, format, "Created: ")
+}
+
+// PrintUpdatedCalendar prints summary info for an updated calendar.
+func PrintUpdatedCalendar(c *calendar.Calendar, format string) {
+	writeCalendarResult(os.Stdout, c, format, "Updated: ")
+}
+
+func writeCalendarResult(w io.Writer, c *calendar.Calendar, format, label string) {
+	if format == "json" {
+		data, _ := json.MarshalIndent(c, "", "  ")
+		fmt.Fprintln(w, string(data))
+		return
+	}
+
+	green := color.New(color.FgGreen, color.Bold)
+	green.Fprint(w, label)
+	fmt.Fprintf(w, "%s\n", c.Title)
+	fmt.Fprintf(w, "  Source: %s\n", c.Source)
+	if c.Color != "" {
+		fmt.Fprintf(w, "  Color:  %s\n", c.Color)
+	}
+	fmt.Fprintf(w, "  ID:     %s\n", c.ID)
 }

--- a/internal/ui/output_test.go
+++ b/internal/ui/output_test.go
@@ -1,12 +1,65 @@
 package ui
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/BRO3886/go-eventkit"
 	"github.com/BRO3886/go-eventkit/calendar"
 )
+
+// add and update honour -o like every other command: a script that creates an
+// event must be able to parse the result rather than scrape the summary.
+func TestWriteEventResultJSON(t *testing.T) {
+	const id = "00000000-1111-2222-3333-444444444444:AAAAAAAA-0000-0000-0000-00000000000A"
+	event := calendar.Event{ID: id, Title: "Interview - round 2", Calendar: "Work"}
+
+	var buf bytes.Buffer
+	writeEventResult(&buf, &event, "json", "Created: ")
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ngot: %s", err, buf.String())
+	}
+	if got["id"] != id {
+		t.Errorf("id = %v, want %s", got["id"], id)
+	}
+	if strings.Contains(buf.String(), "Created:") {
+		t.Error("JSON output carries the human summary label")
+	}
+}
+
+func TestWriteEventResultTable(t *testing.T) {
+	const id = "00000000-1111-2222-3333-444444444444:AAAAAAAA-0000-0000-0000-00000000000A"
+	event := calendar.Event{ID: id, Title: "Interview - round 2", Calendar: "Work"}
+
+	var buf bytes.Buffer
+	writeEventResult(&buf, &event, "table", "Created: ")
+
+	out := buf.String()
+	if !strings.Contains(out, "Created: ") || !strings.Contains(out, "Interview - round 2") {
+		t.Errorf("summary missing from table output: %q", out)
+	}
+	// The full ID is what --id accepts; a truncated one identifies no event.
+	if !strings.Contains(out, id) {
+		t.Errorf("full ID missing from table output: %q", out)
+	}
+}
+
+func TestWriteCalendarResultJSON(t *testing.T) {
+	cal := calendar.Calendar{ID: "CAL-1", Title: "Work"}
+
+	var buf bytes.Buffer
+	writeCalendarResult(&buf, &cal, "json", "Created: ")
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ngot: %s", err, buf.String())
+	}
+}
 
 func TestFormatRecurrenceRule(t *testing.T) {
 	until := time.Date(2027, 3, 15, 0, 0, 0, 0, time.UTC)

--- a/internal/ui/output_test.go
+++ b/internal/ui/output_test.go
@@ -8,30 +8,6 @@ import (
 	"github.com/BRO3886/go-eventkit/calendar"
 )
 
-func TestShortID(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"abcdefgh-1234-5678", "abcdefgh-1234"},
-		{"short", "short"},
-		{"1234567890123", "1234567890123"},
-		{"", ""},
-		{"1234567", "1234567"},
-		{"12345678901234", "1234567890123"},
-		{"577B8983-DF44-4665-966E-58129A363B3A:20250212", "577B8983-DF44"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := ShortID(tt.input)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestFormatRecurrenceRule(t *testing.T) {
 	until := time.Date(2027, 3, 15, 0, 0, 0, 0, time.UTC)
 


### PR DESCRIPTION
Fixes #55 — `ical delete <partial-id>` deleting a different event than the one named.

## What was wrong

`ical add` printed a 13-character truncation of the event ID. On macOS an identifier is `<store UUID>:<event UUID>`, so those 13 characters are identical for every event in the store — the printed "ID" named no event at all.

Fed back to `delete`, that string reached `findEventByPrefix`, whose exact-match step trusted `client.Event(input)`. `EKEventStore.eventWithIdentifier:` resolves a partial identifier to an arbitrary event instead of failing, so the lookup succeeded, the prefix-matching branch below was never reached, and `delete -f` removed whichever event EventKit had returned. Silently: macOS Calendar has no per-event trash and the output looks like a normal success.

## The fix

**`fix: reject event identifiers that do not round-trip`**

Both lookups in `findEventByPrefix` now check that the event handed back carries the ID that was asked for. Anything else falls through to the prefix search, which already reports ambiguity properly:

```
$ ical delete 9933123D-95D5 -f
Error: Multiple events match "9933123D-95D5". Be more specific:
  9933123D-95D5-…:8183FE13-…  <event> (Aug 26 07:00)
  9933123D-95D5-…:A467A73F-…  <event> (Aug 29 03:30)
  …
```

A partial ID that is genuinely unique still resolves — this narrows the resolver, it does not disable prefix matching.

The row-number path gets the same guard. A cached ID from a listing that has since been deleted also resolves to a stranger, so the existing "Event may have been deleted since listing; fall through to search" fallback could never actually trigger.

`findEventByPrefix` now takes a two-method interface rather than `*calendar.Client`, so the resolver is testable without a live EventKit store.

**`fix: print full event IDs instead of a 13-char prefix`**

`PrintCreatedEvent`, `PrintUpdatedEvent` and the interactive update header print the full ID — the form `--id` accepts, and the only form that identifies one event. `ShortID` has no remaining callers and no correct behaviour under this identifier format, so it and its test are removed.

## Tests

`cmd/ical/commands/show_test.go`, five cases, no EventKit dependency. A fake lookup reproduces the lenient EventKit resolution. Against the unguarded resolver three of them fail:

```
--- FAIL: TestFindEventByPrefixRejectsLenientMatch
    resolved an ambiguous ID to "…"; nothing should have matched
--- FAIL: TestFindEventByPrefixRejectsStaleRowNumber
--- FAIL: TestFindEventByPrefixNoMatch
```

The other two (exact ID, unique prefix) pass either way — they pin that normal resolution still works.

`go test ./...` and `go vet ./...` are clean.

## Verified against a real calendar

On a store of ~800 events: `show`/`delete` with a truncated ID now error and list candidates instead of acting; `add` prints the full `UUID:UUID`; `delete --id <full>` still works. Full JSON exports taken before and after the run are identical — no event lost, nothing left behind.
