### PR TITLE
refactor: use go-eventkit userargs/dateparser instead of local copies

### DIFF
--- a/cmd/ical/commands/add.go
+++ b/cmd/ical/commands/add.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BRO3886/go-eventkit"
 	"github.com/BRO3886/go-eventkit/calendar"
 	"github.com/BRO3886/go-eventkit/dateparser"
+	"github.com/BRO3886/go-eventkit/userargs"
 	"github.com/BRO3886/ical/internal/ui"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
@@ -97,11 +98,11 @@ var addCmd = &cobra.Command{
 		}
 
 		// Parse alerts
-		for _, a := range addAlerts {
-			d, err := dateparser.ParseAlertDuration(a)
-			if err != nil {
-				return err
-			}
+		offsets, err := userargs.ParseAlertOffsets(addAlerts)
+		if err != nil {
+			return err
+		}
+		for _, d := range offsets {
 			input.Alerts = append(input.Alerts, calendar.Alert{RelativeOffset: -d})
 		}
 
@@ -424,15 +425,17 @@ func runAddInteractive() error {
 
 	// Parse alerts
 	if strings.TrimSpace(alertStr) != "" {
+		var fields []string
 		for _, a := range strings.Split(alertStr, ",") {
-			a = strings.TrimSpace(a)
-			if a == "" {
-				continue
+			if a = strings.TrimSpace(a); a != "" {
+				fields = append(fields, a)
 			}
-			d, err := dateparser.ParseAlertDuration(a)
-			if err != nil {
-				return err
-			}
+		}
+		offsets, err := userargs.ParseAlertOffsets(fields)
+		if err != nil {
+			return err
+		}
+		for _, d := range offsets {
 			input.Alerts = append(input.Alerts, calendar.Alert{RelativeOffset: -d})
 		}
 	}
@@ -540,17 +543,7 @@ func repeatUntilBound(t time.Time, loc *time.Location) time.Time {
 	if loc != nil {
 		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc)
 	}
-	return endOfDayIfMidnight(t)
-}
-
-var weekdayMap = map[string]eventkit.Weekday{
-	"sun": eventkit.Sunday, "sunday": eventkit.Sunday,
-	"mon": eventkit.Monday, "monday": eventkit.Monday,
-	"tue": eventkit.Tuesday, "tuesday": eventkit.Tuesday,
-	"wed": eventkit.Wednesday, "wednesday": eventkit.Wednesday,
-	"thu": eventkit.Thursday, "thursday": eventkit.Thursday,
-	"fri": eventkit.Friday, "friday": eventkit.Friday,
-	"sat": eventkit.Saturday, "saturday": eventkit.Saturday,
+	return dateparser.EndOfDayIfMidnight(t)
 }
 
 // buildCalendarOptions builds huh.Option list from writable calendars.
@@ -570,20 +563,19 @@ func buildCalendarOptions(calendars []calendar.Calendar, current string) []huh.O
 	return opts
 }
 
+// parseRepeatDays splits the comma-separated --repeat-days value and defers the
+// per-token weekday lookup to userargs.ParseWeekdays, which accepts the same
+// 3-letter and full names this used to hard-code (plus 2-letter iCalendar
+// codes like "MO").
 func parseRepeatDays(s string) ([]eventkit.Weekday, error) {
 	if s == "" {
 		return nil, nil
 	}
 
 	parts := strings.Split(s, ",")
-	days := make([]eventkit.Weekday, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(strings.ToLower(p))
-		d, ok := weekdayMap[p]
-		if !ok {
-			return nil, fmt.Errorf("unknown day %q (use mon,tue,wed,thu,fri,sat,sun)", p)
-		}
-		days = append(days, d)
+	days, err := userargs.ParseWeekdays(parts)
+	if err != nil {
+		return nil, fmt.Errorf("%w (use mon,tue,wed,thu,fri,sat,sun)", err)
 	}
 	return days, nil
 }

--- a/cmd/ical/commands/dateparser_test.go
+++ b/cmd/ical/commands/dateparser_test.go
@@ -426,40 +426,6 @@ func TestParseAlertDuration(t *testing.T) {
 	}
 }
 
-// TestEndOfDayIfMidnight verifies the --to date bumping logic.
-func TestEndOfDayIfMidnight(t *testing.T) {
-	tests := []struct {
-		name string
-		in   time.Time
-		want time.Time
-	}{
-		{
-			"midnight gets bumped",
-			time.Date(2026, 2, 12, 0, 0, 0, 0, time.Local),
-			time.Date(2026, 2, 12, 23, 59, 59, 0, time.Local),
-		},
-		{
-			"non-midnight unchanged",
-			time.Date(2026, 2, 12, 14, 30, 0, 0, time.Local),
-			time.Date(2026, 2, 12, 14, 30, 0, 0, time.Local),
-		},
-		{
-			"1am unchanged",
-			time.Date(2026, 2, 12, 1, 0, 0, 0, time.Local),
-			time.Date(2026, 2, 12, 1, 0, 0, 0, time.Local),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := endOfDayIfMidnight(tt.in)
-			if !got.Equal(tt.want) {
-				t.Errorf("got %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // TestDateparserWithOptions verifies that go-eventkit v0.4.0 options work.
 func TestDateparserWithOptions(t *testing.T) {
 	ist := mustLoadLoc(t, "Asia/Kolkata")

--- a/cmd/ical/commands/delete.go
+++ b/cmd/ical/commands/delete.go
@@ -217,7 +217,7 @@ func init() {
 func pickEvent(client *calendar.Client, fromStr, toStr string, days int) (*calendar.Event, error) {
 	now := time.Now()
 
-	from := startOfDay(now)
+	from := dateparser.StartOfDay(now)
 	if fromStr != "" {
 		t, err := dateparser.ParseDate(fromStr)
 		if err != nil {
@@ -232,7 +232,7 @@ func pickEvent(client *calendar.Client, fromStr, toStr string, days int) (*calen
 		if err != nil {
 			return nil, fmt.Errorf("invalid --to date: %w", err)
 		}
-		to = endOfDayIfMidnight(t)
+		to = dateparser.EndOfDayIfMidnight(t)
 	}
 
 	events, err := client.Events(from, to)

--- a/cmd/ical/commands/delete_test.go
+++ b/cmd/ical/commands/delete_test.go
@@ -166,13 +166,3 @@ func TestDeletedMessage(t *testing.T) {
 		})
 	}
 }
-
-// TestStartOfDay verifies the start-of-day helper.
-func TestStartOfDay(t *testing.T) {
-	input := time.Date(2026, 3, 15, 14, 30, 45, 123, time.Local)
-	want := time.Date(2026, 3, 15, 0, 0, 0, 0, time.Local)
-	got := startOfDay(input)
-	if !got.Equal(want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-}

--- a/cmd/ical/commands/export.go
+++ b/cmd/ical/commands/export.go
@@ -40,7 +40,7 @@ var exportCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("invalid --to date: %w", err)
 			}
-			to = endOfDayIfMidnight(t)
+			to = dateparser.EndOfDayIfMidnight(t)
 		}
 
 		client, err := calendar.New()

--- a/cmd/ical/commands/free.go
+++ b/cmd/ical/commands/free.go
@@ -47,7 +47,7 @@ Defaults to the next 24 hours; use --from/--to to change the window.`,
 			if err != nil {
 				return fmt.Errorf("invalid --to: %w", err)
 			}
-			end = endOfDayIfMidnight(t)
+			end = dateparser.EndOfDayIfMidnight(t)
 		}
 
 		client, err := calendar.New()

--- a/cmd/ical/commands/list.go
+++ b/cmd/ical/commands/list.go
@@ -34,7 +34,7 @@ var listCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		now := time.Now()
 
-		from := startOfDay(now)
+		from := dateparser.StartOfDay(now)
 		if listFrom != "" {
 			t, err := dateparser.ParseDate(listFrom)
 			if err != nil {
@@ -49,7 +49,7 @@ var listCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("invalid --to date: %w", err)
 			}
-			to = endOfDayIfMidnight(t)
+			to = dateparser.EndOfDayIfMidnight(t)
 		}
 
 		return listEvents(from, to)
@@ -250,20 +250,6 @@ func filterIncludedCalendars(events []calendar.Event, include []string) []calend
 		}
 	}
 	return filtered
-}
-
-func startOfDay(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
-}
-
-// endOfDayIfMidnight bumps a midnight time to 23:59:59 so that --to "feb 12"
-// means "through the end of Feb 12" rather than "up to the start of Feb 12".
-// If the time has an explicit hour/minute (not midnight), it's left as-is.
-func endOfDayIfMidnight(t time.Time) time.Time {
-	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 {
-		return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, t.Location())
-	}
-	return t
 }
 
 // attendeeMatches returns true if any attendee name/email or the organizer

--- a/cmd/ical/commands/search.go
+++ b/cmd/ical/commands/search.go
@@ -45,7 +45,7 @@ var searchCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("invalid --to date: %w", err)
 			}
-			to = endOfDayIfMidnight(t)
+			to = dateparser.EndOfDayIfMidnight(t)
 		}
 
 		client, err := calendar.New()

--- a/cmd/ical/commands/today.go
+++ b/cmd/ical/commands/today.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"time"
 
+	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +13,8 @@ var todayCmd = &cobra.Command{
 	Long:  "Shortcut for 'cal list --from today --to tomorrow'. Shows the day's agenda.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		now := time.Now()
-		from := startOfDay(now)
-		to := startOfDay(now.AddDate(0, 0, 1))
+		from := dateparser.StartOfDay(now)
+		to := dateparser.StartOfDay(now.AddDate(0, 0, 1))
 		return listEvents(from, to)
 	},
 }

--- a/cmd/ical/commands/upcoming.go
+++ b/cmd/ical/commands/upcoming.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"time"
 
+	"github.com/BRO3886/go-eventkit/dateparser"
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +16,8 @@ var upcomingCmd = &cobra.Command{
 	Long:    "Shortcut for 'cal list' with --from today --to 'in N days'.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		now := time.Now()
-		from := startOfDay(now)
-		to := startOfDay(now.AddDate(0, 0, upcomingDays))
+		from := dateparser.StartOfDay(now)
+		to := dateparser.StartOfDay(now.AddDate(0, 0, upcomingDays))
 		return listEvents(from, to)
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/ical
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.15.0
+	github.com/BRO3886/go-eventkit v0.16.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/fatih/color v1.18.0
 	github.com/mattn/go-runewidth v0.0.19


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — blocked on [BRO3886/go-eventkit#11](https://github.com/BRO3886/go-eventkit/pull/11).** This will not build until that PR merges and a tag containing the `userargs` package is cut. `go.mod` optimistically requires `v0.16.0`; adjust to whatever version actually ships. Opening it now so the payoff of #11 is concrete rather than hypothetical.

## What this does

`ical` carries its own copies of logic that go-eventkit#11 adds to the library. This deletes the copies.

| Removed from `ical` | Replaced with |
| --- | --- |
| `startOfDay`, `endOfDayIfMidnight` (`list.go`) | `dateparser.StartOfDay`, `dateparser.EndOfDayIfMidnight` — the implementations were byte-identical |
| `weekdayMap` (`add.go`) | `userargs.ParseWeekdays` |
| the `ParseAlertDuration`-and-negate loop, written twice | `userargs.ParseAlertOffsets` |

Net **-101 / +37** lines across 10 files.

Details:

- **Day boundaries.** All 8 call sites (`list`, `delete`, `today`, `upcoming`, `export`, `free`, `search`, plus `repeatUntilBound`) now call the library. The two tests that covered the moved helpers are dropped, since `dateparser/time_bounds_test.go` covers the same cases upstream — say the word if you'd rather keep them as consumer-side contract tests.
- **Weekdays.** `parseRepeatDays` keeps the comma splitting and defers the per-token lookup. Side effect: `--repeat-days` now also accepts 2-letter iCalendar codes (`MO`, `WE`) on top of the existing 3-letter and full names. Widening only — nothing that parsed before stops parsing.
- **Alerts.** `ParseAlertOffsets` additionally rejects offsets beyond a year. Those previously overflowed into *negative* durations, which `Alert{RelativeOffset: -d}` flipped into a positive offset — i.e. `--alert 99999999999999999d` silently scheduled the alarm long *after* the event. See the overflow fix in #11.

## What this deliberately does *not* do

`buildRecurrenceRule` is **not** replaced by `userargs.ParseRecurrence`, even though that looks like the obvious swap.

`buildRecurrenceRule` applies a timezone-aware end-of-day bound to `--repeat-until` via `repeatUntilBound` (#39 — series ending a day early). `ParseRecurrence` calls `rule.Until(t)` with the raw parsed date and has no way to express that bound, so swapping it in would regress #39. The library function is the right shape for MCP-style callers that have no per-event timezone; `ical` is not one of those. Happy to add an option to `ParseRecurrence` if you'd prefer the paths converge.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` all pass against the #11 branch via a local `replace`. `gofmt -l` reports exactly the same 7 pre-existing files before and after this change — no formatting regressions, and I did not reformat anything out of scope.

Porting this surfaced one bug in #11 itself: `ParseAlertOffsets` rejected a zero offset, which would have broken `ical`'s `--alert 0m` ("alert at time of event"). Fixed in #11 rather than worked around here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2ezyXUT3MZAUieGU7tPca
